### PR TITLE
feat: envoi d'un email de notification lors du changement de mot de passe

### DIFF
--- a/app/Controllers/UserController.php
+++ b/app/Controllers/UserController.php
@@ -4,6 +4,7 @@ namespace App\Controllers;
 
 use App\Models\UserModel;
 use App\Models\CityModel;
+use App\Libraries\MailerExample;
 use CodeIgniter\I18n\Time;
 
 class UserController extends BaseController
@@ -157,6 +158,14 @@ class UserController extends BaseController
         // Hachage du nouveau mot de passe si renseigné
         if (!empty($newPassword)) {
             $data['password_hash'] = password_hash($newPassword, PASSWORD_DEFAULT);
+
+            // Envoi de la notification par email
+            $mailer = new MailerExample();
+            $mailer->sendHtml(
+            $user['email'],
+            'Votre mot de passe a été modifié',
+            $this->passwordChangedEmail($user['firstname'], $user['lastname'])
+            );
         }
 
         // Gestion de l'upload de l'avatar
@@ -179,5 +188,30 @@ class UserController extends BaseController
         ]);
 
         return redirect()->to(site_url('profile'))->with('success', 'Profil mis à jour avec succès.');
+    }
+
+    /**
+     * Construit le corps HTML de l'email de notification de changement de mot de passe
+     *
+     * @param  string $firstname Prénom de l'utilisateur 
+     * @param  string $lastname  Nom de l'utilisateur
+     * @return string Corps HTML de l'email
+     */
+    private function passwordChangedEmail(string $firstname, string $lastname): string
+    {
+        $date    = ucfirst(Time::now('Europe/Paris', 'fr_FR')->toLocalizedString('d MMMM yyyy à HH:mm'));
+        $appName = env('mailer.fromName');
+        $support = env('mailer.from');
+
+        return <<<HTML
+        <p>Bonjour {$firstname} {$lastname},</p>
+
+        <p>Nous vous confirmons que votre mot de passe a bien été modifié le <strong>{$date}</strong>.</p>
+
+        <p>Si vous n'êtes pas à l'origine de cette modification, contactez-nous immédiatement à
+        <a href="mailto:{$support}">{$support}</a>.</p>
+
+        <p>— L'équipe {$appName}</p>
+        HTML;
     }
 }


### PR DESCRIPTION
Ajout d'une notification email lors du changement de mot de passe

Lorsqu'un utilisateur modifie son mot de passe depuis son profil, un email
lui est automatiquement envoyé pour l'en informer.

L'email contient :
- Le prénom et nom de l'utilisateur
- La date et l'heure de la modification
- Un contact support en cas d'usage frauduleux