### PR TITLE
fix: affichage du message d'erreur ville/CP sur la page profil

### DIFF
--- a/app/Views/Auth/register.php
+++ b/app/Views/Auth/register.php
@@ -122,9 +122,7 @@
             </div>
           </div>
           <!-- Message d'erreur -->
-          <div>
-              <p class="errorMessage text-red-600 mb-4"></p>
-          </div>
+          <p class="errorMessage text-red-600 mb-4 hidden"></p>
           
           <div class="flex items-start gap-2.5 bg-action/5 border border-action/15 rounded-lg px-3 py-2.5">
             <i class="fa-solid fa-circle-info text-action/60 text-sm mt-0.5 shrink-0"></i>

--- a/app/Views/profile/edit.php
+++ b/app/Views/profile/edit.php
@@ -127,6 +127,9 @@
           </div>
         </div>
 
+          <!-- Message d'erreur -->
+          <p class="errorMessage text-red-600 mb-4 w-full hidden"></p>
+
       </div>
     </div>
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -9,6 +9,10 @@ if (cityInput && zipInput) {
 
   let isValid = false;
 
+  if (cityInput.value.trim() && zipInput.value.trim().length === 5) {
+    isValid = true;
+  }
+
   /**
    * @var {HTMLDivElement} dropdown - Création dynamique de l'élément conteneur 
    * qui affichera la liste des suggestions sous le champ de saisie de la Ville.
@@ -34,7 +38,10 @@ if (cityInput && zipInput) {
 
     cityInput.style.borderColor = "";
     zipInput.style.borderColor = "";
-    if (errorText) errorText.textContent = "";
+    if (errorText) {
+      errorText.textContent = "";
+      errorText.classList.add('hidden');
+    }
 
     if (val.length < 2) { closeDropdown(); return; }
     debounceTimer = setTimeout(() => fetchCities(val), 250);
@@ -50,7 +57,10 @@ if (cityInput && zipInput) {
 
     cityInput.style.borderColor = "";
     zipInput.style.borderColor = "";
-    if (errorText) errorText.textContent = "";
+    if (errorText) {
+      errorText.textContent = "";
+      errorText.classList.add('hidden');
+    }
 
     if (zipVal.length === 5 && /^\d+$/.test(zipVal)) {
       try {
@@ -63,12 +73,16 @@ if (cityInput && zipInput) {
           isValid = true;
           cityInput.style.borderColor = "";
           zipInput.style.borderColor = "";
-          if (errorText) errorText.textContent = "";
+          if (errorText) {
+            errorText.textContent = "";
+            errorText.classList.add('hidden');
+          }
         } else {
           zipInput.style.borderColor = "red";
           isValid = false;
           if (errorText) {
             errorText.textContent = "Le code postal et la ville ne correspondent pas à une commune valide.";
+            errorText.classList.remove('hidden');
           }
         }
       } catch (error) {
@@ -139,13 +153,17 @@ if (cityInput && zipInput) {
         isValid = true;
         cityInput.style.borderColor = ""; // Remet le champ à son aspect normal
         zipInput.style.borderColor = "";
-        if (errorText) errorText.textContent = "";
+        if (errorText) {
+          errorText.textContent = "";
+          errorText.classList.add('hidden');
+        }
       } else {
         cityInput.style.borderColor = "red";
         zipInput.style.borderColor = "red";
         isValid = false;
         if (errorText) {
           errorText.textContent = "Le code postal et la ville ne correspondent pas à une commune valide.";
+          errorText.classList.remove('hidden');
         }
       }
     } catch (error) {
@@ -202,6 +220,7 @@ if (cityInput && zipInput) {
       if (!isValid) {
         e.preventDefault(); // Bloque l'envoi vers PHP si la ville est incorrecte
         errorText.textContent = "Le code postal et la ville ne correspondent pas à une commune valide.";
+        errorText.classList.remove('hidden');
       }
     });
   }


### PR DESCRIPTION
Le message d'erreur de validation ville/code postal ne s'affichait pas 
sur la page de modification du profil, contrairement à la page d'inscription 
où il fonctionnait correctement.

Corrections apportées :
- Ajout de l'élément <p class="errorMessage"> manquant dans le HTML
- Gestion de la classe Tailwind `hidden` via classList.add/remove 
  sur tous les points d'affichage et de masquage du message
- Initialisation de isValid à true si ville et CP sont déjà renseignés au chargement de la page