### PR TITLE
ajoute une étape de prévisualisation avant la publication d'un trajet

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -81,10 +81,13 @@ $routes->group('', ['filter' => 'auth'], function ($routes) {
     $routes->post('journeys/(:num)/book',             'BookingController::create/$1');
 
     // Journeys
-    $routes->get('journeys',                'JourneyController::showAll');
-    $routes->get('journeys/new',            'JourneyController::showCreateForm');
-    $routes->post('journeys/new',           'JourneyController::create');
-    $routes->get('journeys/(:num)',         'JourneyController::show/$1');
+    $routes->get('journeys',                  'JourneyController::showAll');
+    $routes->get('journeys/new',              'JourneyController::showCreateForm');
+    $routes->post('journeys/new',             'JourneyController::create');
+    $routes->get('journeys/preview',          'JourneyController::showPreview');
+    $routes->post('journeys/preview/confirm', 'JourneyController::confirm');
+    $routes->post('journeys/preview/modify',  'JourneyController::modify');
+    $routes->get('journeys/(:num)',           'JourneyController::show/$1');
     $routes->post('journeys/(:num)/cancel', 'JourneyController::cancel/$1');
     $routes->post('journeys/(:num)/delete', 'JourneyController::delete/$1');
 

--- a/app/Controllers/JourneyController.php
+++ b/app/Controllers/JourneyController.php
@@ -55,19 +55,14 @@ class JourneyController extends BaseController{
     /**
      * Traite la soumission du formulaire de création d'un trajet.
      *
-     * Valide les données du formulaire, récupère le tracé via les APIs externes
-     * (géocodage + routage), puis insère l'ensemble (track, locations, journey,
-     * stages) en base via une transaction.
+     * Valide les données, géocode les adresses et calcule le tracé via les APIs
+     * externes, puis stocke l'ensemble en session et redirige vers la page de
+     * confirmation. La persistance en base n'a lieu qu'après confirmation.
      *
-     * Les erreurs sont gérées selon trois familles :
-     *  - validation du formulaire HTTP        → redirection avec erreurs de champs
-     *  - API externe indisponible             → redirection avec message générique
-     *  - validation des models / transaction  → redirection avec erreurs du model
-     *
-     * @return RedirectResponse Redirection vers la page du trajet créé ou
+     * @return RedirectResponse Redirection vers la prévisualisation ou
      *                          retour au formulaire avec les erreurs
      */
-    public function create()
+    public function create(): RedirectResponse
     {
         $userId = session('user_id');
 
@@ -84,43 +79,136 @@ class JourneyController extends BaseController{
 
         // ====== Récupération des données du formulaire
         $createFormData = $this->getCreateFormData();
+        $rawPost        = $this->request->getPost();
 
-        // ====== Traitement métier
+        // ====== Géocodage + calcul du tracé (sans persistance)
         try {
-
             $locationsData = $this->createJourneyService->fetchAllLocationsData($createFormData['location']);
             $geoJsonTrack  = $this->createJourneyService->fetchTrackOrFail($locationsData);
-            $journeyId     = $this->createJourneyService->persistJourney($userId, $createFormData, $locationsData, $geoJsonTrack);
-
         } catch (ExternalApiException $e) {
-
             return redirect()->back()->withInput()
                 ->with('errors', ['api' => 'Service de cartographie indisponible, réessayez plus tard.']);
-
-        } catch (ModelValidationException $e) {
-
-            return redirect()->back()->withInput()
-                ->with('errors', $e->getErrors());
-
         } catch (AddressValidationException $e) {
             return redirect()->back()->withInput()
                 ->with('errors', $e->getErrors());
-
         } catch (\Throwable $e) {
-
             return redirect()->back()->withInput()
-                ->with('errors', ['db' => 'Une erreur est survenue lors de l\'enregistrement .']);
-
+                ->with('errors', ['db' => 'Une erreur est survenue.']);
         }
+
+        // ====== Stockage en session pour la page de confirmation
+        session()->set('journey_preview', [
+            'rawPost'        => $rawPost,
+            'createFormData' => $createFormData,
+            'locationsData'  => $locationsData,
+            'geoJsonTrack'   => $geoJsonTrack,
+        ]);
+
+        return redirect()->to('/journeys/preview');
+    }
+
+    /**
+     * Affiche la page de prévisualisation du trajet avant publication.
+     *
+     * Lit les données géocodées stockées en session par create() et les
+     * transforme en un tableau compatible avec la vue de détail, sans aucun
+     * accès à la base de données pour le trajet lui-même.
+     *
+     * @return string|RedirectResponse Vue de prévisualisation ou redirection
+     *                                 vers le formulaire si la session est absente
+     */
+    public function showPreview(): string|RedirectResponse
+    {
+        $preview = session()->get('journey_preview');
+        if (!$preview) {
+            return redirect()->to('/journeys/new');
+        }
+
+        $userId      = (int) session('user_id');
+        $previewData = $this->createJourneyService->buildPreviewData(
+            $userId,
+            $preview['createFormData'],
+            $preview['locationsData'],
+            $preview['geoJsonTrack']
+        );
+
+        return view('Journeys/journeyPreview', [
+            'title' => 'Confirmer le trajet',
+            ...$previewData,
+        ]);
+    }
+
+    /**
+     * Confirme la publication du trajet : persiste les données en session en base.
+     *
+     * Après persistance, vide la session de prévisualisation, déclenche les
+     * notifications de matching, puis redirige vers la page du trajet créé.
+     *
+     * @return RedirectResponse Redirection vers le trajet ou vers le formulaire
+     *                          en cas d'erreur de persistance
+     */
+    public function confirm(): RedirectResponse
+    {
+        $preview = session()->get('journey_preview');
+        if (!$preview) {
+            return redirect()->to('/journeys/new');
+        }
+
+        $userId = (int) session('user_id');
+
+        try {
+            $journeyId = $this->createJourneyService->persistJourney(
+                $userId,
+                $preview['createFormData'],
+                $preview['locationsData'],
+                $preview['geoJsonTrack']
+            );
+        } catch (ExternalApiException $e) {
+            session()->remove('journey_preview');
+            return redirect()->to('/journeys/new')
+                ->with('errors', ['api' => 'Service de cartographie indisponible, réessayez plus tard.']);
+        } catch (ModelValidationException $e) {
+            session()->remove('journey_preview');
+            return redirect()->to('/journeys/new')
+                ->with('errors', $e->getErrors());
+        } catch (\Throwable $e) {
+            session()->remove('journey_preview');
+            return redirect()->to('/journeys/new')
+                ->with('errors', ['db' => 'Une erreur est survenue lors de l\'enregistrement.']);
+        }
+
+        session()->remove('journey_preview');
 
         // ====== Matching avec les demandes de trajet existantes
         try {
-            $this->journeyService->notifyMatchingRequests($journeyId, $geoJsonTrack);
+            $this->journeyService->notifyMatchingRequests($journeyId, $preview['geoJsonTrack']);
         } catch (\Throwable $e) {
             log_message('error', 'notifyMatchingRequests: ' . $e->getMessage());
         }
 
         return redirect()->to('/journeys/' . $journeyId);
+    }
+
+    /**
+     * Redirige vers le formulaire de création avec les données pré-remplies
+     * depuis la session de prévisualisation, pour permettre la modification.
+     *
+     * @return RedirectResponse Redirection vers le formulaire de création
+     */
+    public function modify(): RedirectResponse
+    {
+        $preview = session()->get('journey_preview');
+        if (!$preview) {
+            return redirect()->to('/journeys/new');
+        }
+
+        session()->setFlashdata('_ci_old_input', [
+            'get'  => [],
+            'post' => $preview['rawPost'],
+        ]);
+        session()->remove('journey_preview');
+
+        return redirect()->to('/journeys/new');
     }
 
     /**

--- a/app/Services/CreateJourneyService.php
+++ b/app/Services/CreateJourneyService.php
@@ -7,6 +7,8 @@ use App\Models\TrackModel;
 use App\Models\LocationModel;
 use App\Models\StageModel;
 use App\Models\CityModel;
+use App\Models\CarModel;
+use App\Models\UserModel;
 
 use App\Exceptions\ExternalApiException;
 use App\Exceptions\ModelValidationException;
@@ -25,6 +27,8 @@ class CreateJourneyService
     protected LocationModel $locationModel;
     protected StageModel $stageModel;
     protected CityModel $cityModel;
+    protected CarModel $carModel;
+    protected UserModel $userModel;
 
     protected RoutingService $routingService;
     protected GeocodingService $geocodingService;
@@ -36,6 +40,8 @@ class CreateJourneyService
         $this->locationModel        = new LocationModel();
         $this->stageModel           = new StageModel();
         $this->cityModel            = new CityModel();
+        $this->carModel             = new CarModel();
+        $this->userModel            = new UserModel();
 
         $this->routingService       = new RoutingService();
         $this->geocodingService     = new GeocodingService();
@@ -238,6 +244,82 @@ class CreateJourneyService
             ->setTime($journeyStartHour, $journeyStartMinute, 0);
     }
 
+
+    /**
+     * Construit les données nécessaires à l'affichage de la page de prévisualisation
+     * d'un trajet, avant sa persistance en base.
+     *
+     * @param  int    $userId          Identifiant du conducteur
+     * @param  array  $createFormData  Données du formulaire (clés 'journey' et 'location')
+     * @param  array  $locationsData   Données de géocodage (clés 'start', 'stage0'…, 'end')
+     * @param  string $geoJsonTrack    Tracé GeoJSON renvoyé par l'API de routage
+     * @return array{journey:array, stages:array, remainingSeats:int}
+     */
+    public function buildPreviewData(int $userId, array $createFormData, array $locationsData, string $geoJsonTrack): array
+    {
+        $user = $this->userModel->find($userId);
+        $car  = $this->carModel->find($createFormData['journey']['car']);
+
+        $startDateTime = $this->buildJourneyStartDateTime($createFormData['journey']);
+
+        $geoData       = json_decode($geoJsonTrack, true);
+        $segments      = $geoData['features'][0]['properties']['segments'] ?? [];
+        $totalDuration = (int) array_sum(array_column($segments, 'duration'));
+        $endDateTime   = $startDateTime->modify('+' . $totalDuration . ' seconds');
+
+        $stageDepartures = $this->computeStageDepartures($createFormData['journey'], $geoJsonTrack);
+
+        $locStart = $locationsData['start'];
+        $locEnd   = $locationsData['end'];
+
+        $journey = [
+            'id'               => null,
+            'user_id'          => $userId,
+            'driver_id'        => $userId,
+            'start_datetime'   => $startDateTime->format('Y-m-d H:i:s'),
+            'end_datetime'     => $endDateTime->format('Y-m-d H:i:s'),
+            'seats'            => $createFormData['journey']['seats'],
+            'note'             => $createFormData['journey']['note'],
+            'smoking'          => $createFormData['journey']['smoking'],
+            'city_start_name'  => $locStart['city'],
+            'address_start'    => $locStart['name'],
+            'lat_start'        => $locStart['latitude'],
+            'lng_start'        => $locStart['longitude'],
+            'city_end_name'    => $locEnd['city'],
+            'address_end'      => $locEnd['name'],
+            'lat_end'          => $locEnd['latitude'],
+            'lng_end'          => $locEnd['longitude'],
+            'driver_firstname' => $user['firstname'],
+            'driver_lastname'  => $user['lastname'],
+            'driver_avatar'    => $user['avatar'] ?? null,
+            'driver_is_student' => $user['is_student'] ?? false,
+            'car_brand'        => $car['brand'],
+            'car_model'        => $car['model'],
+            'car_color'        => $car['color'],
+            'track_geojson'    => $geoJsonTrack,
+            'canceled_at'      => null,
+        ];
+
+        $stages     = [];
+        $stageIndex = 0;
+        foreach ($locationsData as $key => $loc) {
+            if (!str_starts_with($key, 'stage')) continue;
+            $stages[] = [
+                'city_name'      => $loc['city'],
+                'address'        => $loc['name'],
+                'latitude'       => $loc['latitude'],
+                'longitude'      => $loc['longitude'],
+                'departure_time' => $stageDepartures[$stageIndex]->format('H:i:s'),
+            ];
+            $stageIndex++;
+        }
+
+        return [
+            'journey'        => $journey,
+            'stages'         => $stages,
+            'remainingSeats' => (int) $createFormData['journey']['seats'],
+        ];
+    }
 
     /**
      * Calcule les heures de départ de chaque étape intermédiaire à partir

--- a/app/Views/Journeys/journeyPreview.php
+++ b/app/Views/Journeys/journeyPreview.php
@@ -1,0 +1,197 @@
+<?php
+
+/** @var array  $journey */
+/** @var array  $stages */
+/** @var int    $remainingSeats */
+?>
+<?= view('partials/head', [
+    'extraCss' => ['https://unpkg.com/leaflet@1.9.4/dist/leaflet.css'],
+    'extraJs'  => [
+        'https://unpkg.com/leaflet@1.9.4/dist/leaflet.js',
+        base_url('js/journeyMap.js'),
+    ],
+]) ?>
+<?= view('partials/header') ?>
+
+<style>html { scroll-behavior: smooth; }</style>
+
+<div class="max-w-4xl mx-auto py-10 px-4 space-y-4">
+
+    <!-- En-tête -->
+    <div class="mb-6">
+        <div class="flex items-center justify-between gap-4">
+            <h1 class="text-ink text-2xl font-bold font-display">Confirmer le trajet</h1>
+            <div class="flex gap-2 shrink-0">
+                <a href="#actions"
+                   class="inline-flex items-center gap-1.5 bg-action hover:bg-action-dark text-ink font-bold font-display text-sm rounded-full px-4 py-1.5 transition-colors">
+                    <i class="fa-solid fa-check text-xs"></i>Valider
+                </a>
+                <a href="#actions"
+                   class="inline-flex items-center gap-1.5 border border-action/30 hover:border-action/60 text-ink/70 hover:text-ink font-semibold font-display text-sm rounded-full px-4 py-1.5 transition-colors">
+                    <i class="fa-solid fa-pen text-xs"></i>Modifier
+                </a>
+            </div>
+        </div>
+        <p class="text-muted text-sm mt-1">Vérifiez les informations avant de publier.</p>
+    </div>
+
+    <!-- Itinéraire -->
+    <article class="bg-surface-card rounded-2xl p-6 border border-action/10">
+        <?php $fmt = new IntlDateFormatter('fr_FR', IntlDateFormatter::FULL, IntlDateFormatter::NONE, null, null, 'EEEE d MMMM'); ?>
+        <p class="text-muted text-sm mb-4 capitalize"><?= $fmt->format(strtotime($journey['start_datetime'])) ?></p>
+
+        <div class="space-y-0">
+
+            <!-- Départ -->
+            <div class="flex gap-4">
+                <div class="flex flex-col items-center shrink-0 w-3">
+                    <div class="w-3 h-3 bg-brand rounded-full shrink-0"></div>
+                    <div class="w-px flex-1 bg-ink/10 my-1"></div>
+                </div>
+                <div class="flex-1 min-w-0 pb-5">
+                    <p class="text-ink font-bold font-display text-lg leading-none mb-1"><?= esc(date('H:i', strtotime($journey['start_datetime']))) ?></p>
+                    <p class="text-ink font-semibold"><?= esc($journey['city_start_name']) ?></p>
+                    <p class="text-muted text-sm"><?= esc($journey['address_start']) ?></p>
+                </div>
+            </div>
+
+            <!-- Étapes -->
+            <?php foreach ($stages as $stage) : ?>
+                <div class="flex gap-4">
+                    <div class="flex flex-col items-center shrink-0 w-3">
+                        <div class="w-2 h-2 bg-ink/20 mt-0.5 rounded-full shrink-0"></div>
+                        <div class="w-px flex-1 bg-ink/10 my-1"></div>
+                    </div>
+                    <div class="flex-1 min-w-0 pb-5">
+                        <p class="text-muted text-sm leading-none mb-1"><?= esc(substr($stage['departure_time'], 0, 5)) ?></p>
+                        <p class="text-muted text-sm"><?= esc($stage['city_name']) ?></p>
+                        <p class="text-muted/50 text-xs"><?= esc($stage['address']) ?></p>
+                    </div>
+                </div>
+            <?php endforeach ?>
+
+            <!-- Arrivée -->
+            <div class="flex gap-4">
+                <div class="flex flex-col items-center shrink-0 w-3">
+                    <div class="w-3 h-3 rounded-full bg-action shrink-0"></div>
+                </div>
+                <div class="flex-1 min-w-0">
+                    <p class="text-ink font-bold font-display text-lg leading-none mb-1"><?= esc(date('H:i', strtotime($journey['end_datetime']))) ?></p>
+                    <p class="text-ink font-semibold"><?= esc($journey['city_end_name']) ?></p>
+                    <p class="text-muted text-sm"><?= esc($journey['address_end']) ?></p>
+                </div>
+            </div>
+
+        </div>
+
+        <p class="text-muted/60 text-xs mt-4 flex items-start gap-1.5">
+            <i class="fa-solid fa-circle-info text-[10px] mt-0.5 shrink-0"></i>
+            Les horaires affichés sont des estimations calculées dans des conditions de trafic normales.
+        </p>
+    </article>
+
+    <!-- Map du trajet -->
+    <?php
+        $mapWaypoints = array_merge(
+            [['lat' => $journey['lat_start'], 'lng' => $journey['lng_start'], 'label' => $journey['city_start_name']]],
+            array_map(fn($s) => ['lat' => $s['latitude'], 'lng' => $s['longitude'], 'label' => $s['city_name']], $stages),
+            [['lat' => $journey['lat_end'],   'lng' => $journey['lng_end'],   'label' => $journey['city_end_name']]]
+        );
+    ?>
+    <?= view('partials/journeyMap', ['waypoints' => $mapWaypoints, 'geojson' => $journey['track_geojson'] ?? null]) ?>
+
+    <!-- Conducteur -->
+    <article class="bg-surface-card rounded-2xl p-6 border border-action/10">
+        <div class="flex items-baseline justify-between mb-4">
+            <h2 class="text-muted text-xs font-semibold uppercase tracking-wider">Conducteur</h2>
+            <?php if (!empty($journey['note'])): ?>
+                <span class="hidden sm:block text-muted text-xs font-semibold uppercase tracking-wider">Par rapport au trajet</span>
+            <?php endif ?>
+        </div>
+        <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+            <div class="flex items-center gap-4">
+                <?php $initials = strtoupper(substr($journey['driver_firstname'], 0, 1) . substr($journey['driver_lastname'], 0, 1)); ?>
+                <?php if (!empty($journey['driver_avatar'])): ?>
+                    <div class="w-14 h-14 rounded-full overflow-hidden shrink-0">
+                        <img src="<?= site_url(esc($journey['driver_avatar'])) ?>" alt="Avatar de <?= esc($journey['driver_firstname']) ?>" class="w-full h-full object-cover"
+                        onerror="this.parentElement.style.display='none'; this.parentElement.nextElementSibling.style.display='flex';">
+                    </div>
+                    <div class="hidden w-14 h-14 rounded-full bg-action-dark text-ink font-bold text-base shrink-0 items-center justify-center">
+                        <?= esc($initials) ?>
+                    </div>
+                <?php else: ?>
+                    <div class="flex w-14 h-14 rounded-full bg-action-dark text-ink font-bold text-base shrink-0 items-center justify-center">
+                        <?= esc($initials) ?>
+                    </div>
+                <?php endif; ?>
+                <div>
+                    <p class="text-ink font-semibold"><?= esc($journey['driver_firstname']) ?> <?= esc($journey['driver_lastname']) ?></p>
+                    <p class="text-muted text-sm"><?= $journey['driver_is_student'] ? 'Étudiant' : 'Formateur' ?></p>
+                </div>
+            </div>
+
+            <?php if (!empty($journey['note'])): ?>
+                <?php $noteLong = mb_strlen($journey['note']) > 120; ?>
+                <div class="flex flex-col gap-1.5">
+                    <span class="sm:hidden text-muted text-xs font-semibold uppercase tracking-wider">Par rapport au trajet</span>
+                    <blockquote class="flex-1 min-w-0 border-l-2 border-action/40 pl-3 text-muted text-sm italic max-w-xs">
+                        <?php if ($noteLong): ?>
+                            <span class="jsNoteShort"><?= nl2br(esc(mb_substr($journey['note'], 0, 120))) ?>…</span>
+                            <span class="jsNoteFull hidden"><?= nl2br(esc($journey['note'])) ?></span>
+                            <button type="button" onclick="
+                                var s=this.previousElementSibling,sh=s.previousElementSibling;
+                                var open=!s.classList.contains('hidden');
+                                s.classList.toggle('hidden',open); sh.classList.toggle('hidden',!open);
+                                this.textContent=open?'Voir plus':'Voir moins';
+                            " class="block mt-1 text-action text-xs hover:underline">Voir plus</button>
+                        <?php else: ?>
+                            <?= nl2br(esc($journey['note'])) ?>
+                        <?php endif ?>
+                    </blockquote>
+                </div>
+            <?php endif ?>
+        </div>
+
+        <div class="mt-4 pt-4 border-t border-ink/5 flex flex-wrap gap-3 text-sm text-muted">
+            <span class="flex items-center gap-1.5">
+                <i class="fa-solid fa-car text-xs text-brand"></i>
+                <?= esc($journey['car_brand']) ?> <?= esc($journey['car_model']) ?> · <?= esc($journey['car_color']) ?>
+            </span>
+            <span class="flex items-center gap-1.5">
+                <i class="fa-solid fa-<?= $journey['smoking'] ? 'smoking' : 'ban-smoking' ?> text-xs text-brand"></i>
+                <?= $journey['smoking'] ? 'Fumeur' : 'Non-fumeur' ?>
+            </span>
+        </div>
+    </article>
+
+    <!-- Places disponibles + actions -->
+    <article id="actions" class="bg-surface-card rounded-2xl p-6 border border-action/10">
+        <div class="flex items-center justify-between mb-6">
+            <div>
+                <p class="text-muted text-sm"><?= $remainingSeats > 1 ? 'Places disponibles' : 'Place disponible' ?></p>
+                <p class="text-ink font-bold font-display text-2xl"><?= esc($remainingSeats) ?></p>
+            </div>
+        </div>
+
+        <div class="flex flex-col sm:flex-row gap-3">
+            <form action="<?= site_url('journeys/preview/confirm') ?>" method="POST" class="flex-1">
+                <?= csrf_field() ?>
+                <button type="submit"
+                    class="w-full bg-action hover:bg-action-dark text-ink font-bold font-display rounded-full py-3 transition-colors cursor-pointer">
+                    <i class="fa-solid fa-check text-xs mr-1.5"></i>Publier le trajet
+                </button>
+            </form>
+
+            <form action="<?= site_url('journeys/preview/modify') ?>" method="POST" class="flex-1">
+                <?= csrf_field() ?>
+                <button type="submit"
+                    class="w-full border border-action/30 hover:border-action/60 text-ink/70 hover:text-ink font-semibold font-display rounded-full py-3 transition-colors cursor-pointer">
+                    <i class="fa-solid fa-pen text-xs mr-1.5"></i>Modifier
+                </button>
+            </form>
+        </div>
+    </article>
+
+</div>
+
+<?= view('partials/footer') ?>


### PR DESCRIPTION
1. Ajout d'une étape de prévisualisation avant la publication d'un trajet : les données sont géocodées et le tracé calculé dès la soumission du formulaire, puis stockés en session. La persistance en base n'a lieu qu'après confirmation explicite du conducteur, avec possibilité de revenir modifier le formulaire pré-rempli.