### PR TITLE
Feat/complement email

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -10,7 +10,8 @@ use CodeIgniter\Router\RouteCollection;
  *  DEV ONLY — prévisualisation des emails
  * ========================================================= */
 if (ENVIRONMENT === 'development') {
-    $routes->get('dev/email/(:segment)', 'DevController::emailPreview/$1');
+    $routes->get('dev/email/(:segment)',      'DevController::emailPreview/$1');
+    $routes->get('dev/email/(:segment)/send', 'DevController::emailSend/$1');
 }
 
 /* =========================================================
@@ -35,6 +36,9 @@ $routes->post('contact',          'PageController::sendContact');
 
 // Confirmation d'adresse email (accessible à tous : l'utilisateur n'est pas encore connecté)
 $routes->get('verifyEmail', 'AuthController::verifyEmail');
+
+// Désabonnement one-click depuis un email (token signé, sans connexion requise)
+$routes->get('unsubscribe', 'UserController::unsubscribe');
 
 /* =========================================================
  *  ROUTES INVITÉS (interdites aux utilisateurs connectés)
@@ -106,11 +110,13 @@ $routes->group('', ['filter' => 'auth'], function ($routes) {
     $routes->post('journey-requests/(:num)/cancel', 'JourneyRequestController::delete/$1');
 
     // Profile
-    $routes->get('profile',         'UserController::show');
-    $routes->get('profile/edit',    'UserController::showEditForm');
-    $routes->get('profile/update',  'UserController::showEditForm');
-    $routes->post('profile/update', 'UserController::update');
-    $routes->post('profile/delete', 'UserController::delete');
+    $routes->get('profile',                    'UserController::show');
+    $routes->get('profile/edit',               'UserController::showEditForm');
+    $routes->get('profile/update',             'UserController::showEditForm');
+    $routes->post('profile/update',            'UserController::update');
+    $routes->post('profile/delete',            'UserController::delete');
+    $routes->get('profile/notifications',      'UserController::showNotifications');
+    $routes->post('profile/notifications',     'UserController::updateNotifications');
 
     // Users
     $routes->get('users/(:num)', 'UserController::show/$1');

--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -33,6 +33,9 @@ $routes->get('contact',           'PageController::contact');
 $routes->post('contact',          'PageController::sendContact');
 
 
+// Confirmation d'adresse email (accessible à tous : l'utilisateur n'est pas encore connecté)
+$routes->get('verifyEmail', 'AuthController::verifyEmail');
+
 /* =========================================================
  *  ROUTES INVITÉS (interdites aux utilisateurs connectés)
  * ========================================================= */

--- a/app/Controllers/AuthController.php
+++ b/app/Controllers/AuthController.php
@@ -8,6 +8,7 @@ use App\Libraries\MailerExample;
 use \App\Models\UserModel;
 use \App\Models\CityModel;
 use App\Models\RememberTokenModel;
+use App\Models\NotificationPrefModel;
 use DateTime;
 use App\Services\GeocodingService;
 
@@ -350,15 +351,21 @@ class AuthController extends BaseController
             'email_token_expiry' => null,
         ]);
 
-        // Notification aux admins
-        $admins    = $this->userModel->getActiveAdmins();
-        $emailBody = view('Emails/newRegistration', [
-            'firstname' => $user['firstname'],
-            'lastname'  => $user['lastname'],
-            'email'     => $user['email'],
-        ]);
-        $mailer = new MailerExample();
+        // Notification aux admins (selon leur préférence)
+        $admins         = $this->userModel->getActiveAdmins();
+        $notifPrefModel = new NotificationPrefModel();
+        $mailer         = new MailerExample();
         foreach ($admins as $admin) {
+            if (!$notifPrefModel->wantsNotif((int) $admin['id'], 'admin_registration')) continue;
+            $adminId   = (int) $admin['id'];
+            $emailBody = view('Emails/newRegistration', [
+                'firstname'      => $user['firstname'],
+                'lastname'       => $user['lastname'],
+                'email'          => $user['email'],
+                'prefLabel'      => NotificationPrefModel::PREFS['admin_registration'],
+                'unsubscribeUrl' => site_url('unsubscribe?uid=' . $adminId . '&pref=admin_registration&token=' . UserModel::unsubscribeToken($adminId, 'admin_registration')),
+                'preferencesUrl' => site_url('profile/notifications'),
+            ]);
             $mailer->sendHtml($admin['email'], 'Nouvelle demande d\'inscription', $emailBody);
         }
 

--- a/app/Controllers/AuthController.php
+++ b/app/Controllers/AuthController.php
@@ -173,20 +173,23 @@ class AuthController extends BaseController
             return redirect()->back()->withInput()->with('errors', $this->userModel->errors());
         }
 
-        // Notification aux admins
-        $admins = $this->userModel->getActiveAdmins();
-        $emailBody = view('Emails/newRegistration', [
-            'firstname' => $data['firstname'],
-            'lastname'  => $data['lastname'],
-            'email'     => $data['email'],
+        $userId = $this->userModel->getInsertID();
+
+        // Génération et stockage du token de vérification d'email
+        $token = bin2hex(random_bytes(32));
+        $this->userModel->setEmailToken($userId, $token);
+
+        // Envoi de l'email de confirmation à l'utilisateur
+        $verifyLink = base_url('verifyEmail?token=' . $token);
+        $emailBody  = view('Emails/emailVerification', [
+            'firstname'  => $data['firstname'],
+            'verifyLink' => $verifyLink,
         ]);
         $mailer = new MailerExample();
-        foreach ($admins as $admin) {
-            $mailer->sendHtml($admin['email'], 'Nouvelle demande d\'inscription', $emailBody);
-        }
+        $mailer->sendHtml($data['email'], 'Confirmez votre adresse email — Kenweturi', $emailBody);
 
         // Redirection vers la page de connexion avec un message flash
-        return redirect()->to('/login')->with('success', 'Inscription reçue ! Notre équipe va examiner votre demande et vous recevrez une réponse par email.');
+        return redirect()->to('/login')->with('success', 'Inscription reçue ! Consultez votre boîte mail pour confirmer votre adresse email.');
     }
 
     /**
@@ -215,6 +218,10 @@ class AuthController extends BaseController
             //  Vérification du bannissement
             if ((bool)$user['is_banned'] === true) {
                 return redirect()->back()->withInput()->with('error', 'Votre compte a été suspendu par l\'équipe de modération.');
+            }
+            //  Vérification de la confirmation email
+            if ($user['status'] === 'unverified') {
+                return redirect()->back()->withInput()->with('error', 'Veuillez confirmer votre adresse email avant de vous connecter. Consultez votre boîte mail.');
             }
             //  Vérification du status
             if ($user['status'] === 'pending') {
@@ -314,8 +321,53 @@ class AuthController extends BaseController
     }
 
     /**
+     * Valide le token de confirmation d'email et fait passer le compte en 'pending'
+     *
+     * @return RedirectResponse
+     */
+    public function verifyEmail(): RedirectResponse
+    {
+        $token = $this->request->getGet('token');
+
+        if (!$token) {
+            return redirect()->to('/login')->with('error', 'Lien de vérification invalide.');
+        }
+
+        $user = $this->userModel->findByValidEmailToken($token);
+
+        if (!$user) {
+            return redirect()->to('/login')->with('error', 'Ce lien de confirmation est invalide ou a expiré. Veuillez vous réinscrire.');
+        }
+
+        if ($user['status'] !== 'unverified') {
+            return redirect()->to('/login')->with('success', 'Votre adresse email est déjà confirmée.');
+        }
+
+        // Passage en 'pending' et suppression du token
+        $this->userModel->update($user['id'], [
+            'status'             => 'pending',
+            'email_token'        => null,
+            'email_token_expiry' => null,
+        ]);
+
+        // Notification aux admins
+        $admins    = $this->userModel->getActiveAdmins();
+        $emailBody = view('Emails/newRegistration', [
+            'firstname' => $user['firstname'],
+            'lastname'  => $user['lastname'],
+            'email'     => $user['email'],
+        ]);
+        $mailer = new MailerExample();
+        foreach ($admins as $admin) {
+            $mailer->sendHtml($admin['email'], 'Nouvelle demande d\'inscription', $emailBody);
+        }
+
+        return redirect()->to('/login')->with('success', 'Adresse email confirmée ! Notre équipe va examiner votre demande et vous recevrez une réponse par email.');
+    }
+
+    /**
      * Affiche la page de mot de passe oublié
-     * 
+     *
      * @return string
      */
     public function showForgotPasswordForm()

--- a/app/Controllers/BookingController.php
+++ b/app/Controllers/BookingController.php
@@ -9,6 +9,8 @@ use App\Services\JourneyService;
 
 use App\Models\BookingModel;
 use App\Models\JourneyModel;
+use App\Models\NotificationPrefModel;
+use App\Models\UserModel;
 
 use \CodeIgniter\HTTP\RedirectResponse;
 
@@ -25,14 +27,16 @@ class BookingController extends BaseController
 
     protected BookingModel $bookingModel;
     protected JourneyModel $journeyModel;
+    protected NotificationPrefModel $notifPrefModel;
 
     protected BookingService $bookingService;
     protected JourneyService $journeyService;
 
     public function __construct()
     {
-        $this->bookingModel = new BookingModel();
-        $this->journeyModel = new JourneyModel();
+        $this->bookingModel   = new BookingModel();
+        $this->journeyModel   = new JourneyModel();
+        $this->notifPrefModel = new NotificationPrefModel();
 
         $this->bookingService = new BookingService();
         $this->journeyService = new JourneyService();
@@ -101,8 +105,9 @@ class BookingController extends BaseController
 
         if ($bookingId) {
             $booking = $this->bookingModel->findWithDetails((int) $bookingId, $userId);
-            if ($booking) {
-                $date = date('d/m/Y', strtotime($booking['start_datetime'])) . ' à ' . date('H:i', strtotime($booking['start_datetime']));
+            if ($booking && $this->notifPrefModel->wantsNotif((int) $booking['driver_id'], 'booking_request')) {
+                $date  = date('d/m/Y', strtotime($booking['start_datetime'])) . ' à ' . date('H:i', strtotime($booking['start_datetime']));
+                $driverId = (int) $booking['driver_id'];
                 $mailer = new MailerExample();
                 $mailer->sendHtml(
                     $booking['driver_email'],
@@ -114,6 +119,9 @@ class BookingController extends BaseController
                         'cityStart'          => $booking['city_start_name'],
                         'cityEnd'            => $booking['city_end_name'],
                         'date'               => $date,
+                        'prefLabel'          => NotificationPrefModel::PREFS['booking_request'],
+                        'unsubscribeUrl'     => site_url('unsubscribe?uid=' . $driverId . '&pref=booking_request&token=' . UserModel::unsubscribeToken($driverId, 'booking_request')),
+                        'preferencesUrl'     => site_url('profile/notifications'),
                     ])
                 );
             }
@@ -140,21 +148,26 @@ class BookingController extends BaseController
 
         $this->bookingModel->delete($id);
 
-        $date = date('d/m/Y', strtotime($booking['start_datetime'])) . ' à ' . date('H:i', strtotime($booking['start_datetime']));
-
-        $mailer = new MailerExample();
-        $mailer->sendHtml(
-            $booking['driver_email'],
-            'Annulation d\'une réservation',
-            view('Emails/bookingCancelled', [
-                'firstname'          => $booking['driver_firstname'],
-                'passengerFirstname' => $booking['passenger_firstname'],
-                'passengerLastname'  => $booking['passenger_lastname'],
-                'cityStart'          => $booking['city_start_name'],
-                'cityEnd'            => $booking['city_end_name'],
-                'date'               => $date,
-            ])
-        );
+        $driverId = (int) $booking['driver_id'];
+        if ($this->notifPrefModel->wantsNotif($driverId, 'booking_cancelled')) {
+            $date = date('d/m/Y', strtotime($booking['start_datetime'])) . ' à ' . date('H:i', strtotime($booking['start_datetime']));
+            $mailer = new MailerExample();
+            $mailer->sendHtml(
+                $booking['driver_email'],
+                'Annulation d\'une réservation',
+                view('Emails/bookingCancelled', [
+                    'firstname'          => $booking['driver_firstname'],
+                    'passengerFirstname' => $booking['passenger_firstname'],
+                    'passengerLastname'  => $booking['passenger_lastname'],
+                    'cityStart'          => $booking['city_start_name'],
+                    'cityEnd'            => $booking['city_end_name'],
+                    'date'               => $date,
+                    'prefLabel'          => NotificationPrefModel::PREFS['booking_cancelled'],
+                    'unsubscribeUrl'     => site_url('unsubscribe?uid=' . $driverId . '&pref=booking_cancelled&token=' . UserModel::unsubscribeToken($driverId, 'booking_cancelled')),
+                    'preferencesUrl'     => site_url('profile/notifications'),
+                ])
+            );
+        }
 
         return redirect()->to('/dashboard')->with('success', 'Réservation annulée avec succès !');
     }
@@ -235,19 +248,24 @@ class BookingController extends BaseController
 
         $this->bookingModel->update($id, ['status' => 'rejected']);
 
-        $date = date('d/m/Y', strtotime($booking['start_datetime'])) . ' à ' . date('H:i', strtotime($booking['start_datetime']));
-
-        $mailer = new MailerExample();
-        $mailer->sendHtml(
-            $booking['passenger_email'],
-            'Votre réservation n\'a pas été retenue',
-            view('Emails/bookingRejected', [
-                'firstname' => $booking['passenger_firstname'],
-                'cityStart' => $booking['city_start_name'],
-                'cityEnd'   => $booking['city_end_name'],
-                'date'      => $date,
-            ])
-        );
+        $passengerId = (int) $booking['user_id'];
+        if ($this->notifPrefModel->wantsNotif($passengerId, 'booking_rejected')) {
+            $date = date('d/m/Y', strtotime($booking['start_datetime'])) . ' à ' . date('H:i', strtotime($booking['start_datetime']));
+            $mailer = new MailerExample();
+            $mailer->sendHtml(
+                $booking['passenger_email'],
+                'Votre réservation n\'a pas été retenue',
+                view('Emails/bookingRejected', [
+                    'firstname'      => $booking['passenger_firstname'],
+                    'cityStart'      => $booking['city_start_name'],
+                    'cityEnd'        => $booking['city_end_name'],
+                    'date'           => $date,
+                    'prefLabel'      => NotificationPrefModel::PREFS['booking_rejected'],
+                    'unsubscribeUrl' => site_url('unsubscribe?uid=' . $passengerId . '&pref=booking_rejected&token=' . UserModel::unsubscribeToken($passengerId, 'booking_rejected')),
+                    'preferencesUrl' => site_url('profile/notifications'),
+                ])
+            );
+        }
 
         return redirect()->to('/dashboard/bookings')->with('success', 'Réservation refusée.');
     }

--- a/app/Controllers/DashboardController.php
+++ b/app/Controllers/DashboardController.php
@@ -215,6 +215,7 @@ class DashboardController extends BaseController
 
         if ($filter === 'upcoming') {
             $builder->where('journey.start_datetime >=', date('Y-m-d H:i:s'))
+                    ->orderBy('journey.canceled_at IS NULL', 'DESC', false)
                     ->orderBy('journey.start_datetime', 'ASC');
         } elseif ($filter === 'past') {
             $builder->where('journey.start_datetime <', date('Y-m-d H:i:s'))

--- a/app/Controllers/DevController.php
+++ b/app/Controllers/DevController.php
@@ -2,6 +2,8 @@
 
 namespace App\Controllers;
 
+use App\Libraries\MailerExample;
+
 class DevController extends BaseController
 {
     public function __construct()
@@ -17,7 +19,8 @@ class DevController extends BaseController
             'accountBanned', 'accountDeleted', 'adminApproved', 'adminDeletedAccount',
             'adminNewReport', 'adminRejected', 'adminWarn', 'bookingAccepted',
             'bookingCancelled', 'bookingRejected', 'bookingRequest', 'contact',
-            'emailVerification', 'newRegistration', 'passwordChanged', 'resetPassword',
+            'emailVerification', 'journeyCancelled', 'journeyRequestMatch',
+            'newRegistration', 'passwordChanged', 'resetPassword',
         ];
 
         if (!in_array($template, $allowed, true)) {
@@ -25,18 +28,45 @@ class DevController extends BaseController
         }
 
         $data = [
-            'firstname'  => 'Jean',
-            'lastname'   => 'Dupont',
-            'date'       => date('d/m/Y'),
-            'support'    => 'support@kenweturi.fr',
-            'resetLink'  => site_url('reset-password/fake-token-preview'),
-            'verifyLink' => site_url('verifyEmail?token=fake-token-preview'),
-            'name'       => 'Jean Dupont',
-            'email'      => 'jean.dupont@example.com',
-            'subject'    => 'Question sur une réservation',
-            'message'    => 'Bonjour, je souhaite obtenir des informations sur ma réservation du 15 juin. Merci d\'avance.',
+            'firstname'          => 'Jean',
+            'lastname'           => 'Dupont',
+            'date'               => date('d/m/Y'),
+            'support'            => 'support@kenweturi.fr',
+            'resetLink'          => site_url('reset-password/fake-token-preview'),
+            'verifyLink'         => site_url('verifyEmail?token=fake-token-preview'),
+            'name'               => 'Jean Dupont',
+            'email'              => 'jean.dupont@example.com',
+            'subject'            => 'Question sur une réservation',
+            'message'            => 'Bonjour, je souhaite obtenir des informations sur ma réservation du 15 juin. Merci d\'avance.',
+            'passengerFirstname' => 'Marie',
+            'passengerLastname'  => 'Martin',
+            'driverFirstname'    => 'Jean',
+            'driverLastname'     => 'Dupont',
+            'cityStart'          => 'Paris',
+            'cityEnd'            => 'Lyon',
+            'journeyUrl'         => site_url('journeys/1'),
+            'reporterId'         => 42,
+            'journeyId'          => 7,
+            'description'        => 'Le conducteur a eu un comportement inapproprié.',
+            'prefLabel'          => 'Notifications (prévisualisation)',
+            'unsubscribeUrl'     => site_url('unsubscribe?uid=1&pref=booking_request&token=preview'),
+            'preferencesUrl'     => site_url('profile/notifications'),
         ];
 
         return view('Emails/' . $template, $data);
+    }
+
+    public function emailSend(string $template): string
+    {
+        $html = $this->emailPreview($template);
+
+        $to = $this->request->getGet('to') ?: env('mailer.from');
+
+        $mailer = new MailerExample();
+        $sent   = $mailer->sendHtml($to, "[DEV] Preview : {$template}", $html);
+
+        return $sent
+            ? "<p style='font-family:sans-serif;padding:20px'>✅ Email <strong>{$template}</strong> envoyé à <strong>{$to}</strong>.</p>"
+            : "<p style='font-family:sans-serif;padding:20px;color:red'>❌ Échec de l'envoi. Vérifie les logs et la config SMTP dans <code>.env</code>.</p>";
     }
 }

--- a/app/Controllers/DevController.php
+++ b/app/Controllers/DevController.php
@@ -17,7 +17,7 @@ class DevController extends BaseController
             'accountBanned', 'accountDeleted', 'adminApproved', 'adminDeletedAccount',
             'adminNewReport', 'adminRejected', 'adminWarn', 'bookingAccepted',
             'bookingCancelled', 'bookingRejected', 'bookingRequest', 'contact',
-            'newRegistration', 'passwordChanged', 'resetPassword',
+            'emailVerification', 'newRegistration', 'passwordChanged', 'resetPassword',
         ];
 
         if (!in_array($template, $allowed, true)) {
@@ -30,6 +30,7 @@ class DevController extends BaseController
             'date'       => date('d/m/Y'),
             'support'    => 'support@kenweturi.fr',
             'resetLink'  => site_url('reset-password/fake-token-preview'),
+            'verifyLink' => site_url('verifyEmail?token=fake-token-preview'),
             'name'       => 'Jean Dupont',
             'email'      => 'jean.dupont@example.com',
             'subject'    => 'Question sur une réservation',

--- a/app/Controllers/JourneyRequestController.php
+++ b/app/Controllers/JourneyRequestController.php
@@ -6,6 +6,7 @@ use App\Controllers\BaseController;
 use App\Models\JourneyRequestModel;
 use App\Models\CityModel;
 use App\Models\LocationModel;
+use App\Services\JourneyService;
 use CodeIgniter\HTTP\RedirectResponse;
 
 class JourneyRequestController extends BaseController
@@ -237,6 +238,8 @@ class JourneyRequestController extends BaseController
         if (!$this->journeyRequestModel->update($id, $data)) {
             return redirect()->back()->withInput()->with('errors', $this->journeyRequestModel->errors());
         }
+
+        (new JourneyService())->notifyMatchingJourneys($id, $userId);
 
         $back = $this->validateBackUrl($this->request->getPost('back'));
 

--- a/app/Controllers/JourneyRequestController.php
+++ b/app/Controllers/JourneyRequestController.php
@@ -154,7 +154,7 @@ class JourneyRequestController extends BaseController
         $data = [
             'start_datetime'    => $startDatetime->format('Y-m-d H:i:s'),
             'seats'             => $this->request->getPost('seats') ?: null,
-            'radius_km'         => (float) ($this->request->getPost('radius_km') ?: 10),
+            'radius_km'         => (float) ($this->request->getPost('radius_km') ?: 1),
             'message'           => $this->request->getPost('message') ?: null,
             'user_id'           => $userId,
             'location_start_id' => $startLocationId,
@@ -193,7 +193,8 @@ class JourneyRequestController extends BaseController
      */
     public function update(int $id): RedirectResponse
     {
-        $journeyRequest = $this->journeyRequestModel->where('user_id', session()->get('user_id'))->find($id);
+        $userId         = (int) session()->get('user_id');
+        $journeyRequest = $this->journeyRequestModel->where('user_id', $userId)->find($id);
 
         if (!$journeyRequest) {
             return redirect()->to('/journey-requests')->with('error', self::NOT_FOUND);
@@ -233,7 +234,7 @@ class JourneyRequestController extends BaseController
             'location_end_id'   => $endLocationId,
             'start_datetime'    => $startDatetime->format('Y-m-d H:i:s'),
             'seats'             => $this->request->getPost('seats') ?: null,
-            'radius_km'         => (float) ($this->request->getPost('radius_km') ?: 10),
+            'radius_km'         => (float) ($this->request->getPost('radius_km') ?: 1),
             'message'           => $this->request->getPost('message'),
         ];
 

--- a/app/Controllers/JourneyRequestController.php
+++ b/app/Controllers/JourneyRequestController.php
@@ -154,6 +154,7 @@ class JourneyRequestController extends BaseController
         $data = [
             'start_datetime'    => $startDatetime->format('Y-m-d H:i:s'),
             'seats'             => $this->request->getPost('seats') ?: null,
+            'radius_km'         => (float) ($this->request->getPost('radius_km') ?: 10),
             'message'           => $this->request->getPost('message') ?: null,
             'user_id'           => $userId,
             'location_start_id' => $startLocationId,
@@ -232,6 +233,7 @@ class JourneyRequestController extends BaseController
             'location_end_id'   => $endLocationId,
             'start_datetime'    => $startDatetime->format('Y-m-d H:i:s'),
             'seats'             => $this->request->getPost('seats') ?: null,
+            'radius_km'         => (float) ($this->request->getPost('radius_km') ?: 10),
             'message'           => $this->request->getPost('message'),
         ];
 

--- a/app/Controllers/ReportController.php
+++ b/app/Controllers/ReportController.php
@@ -6,6 +6,8 @@ use App\Models\ReportModel;
 use App\Models\JourneyModel;
 use App\Models\UserModel;
 use App\Models\BookingModel;
+use App\Models\NotificationPrefModel;
+use App\Libraries\MailerExample;
 use CodeIgniter\Exceptions\PageNotFoundException;
 use Config\Services;
 
@@ -162,16 +164,25 @@ class ReportController extends BaseController
 
     private function notifyAdmin(array $journey, string $description, int $reporterId): void
     {
-        $email = Services::email();
+        $notifPrefModel = new NotificationPrefModel();
+        $admins         = $this->userModel->getActiveAdmins();
+        $mailer         = new MailerExample();
 
-        $email->setTo(getenv('ADMIN_EMAIL') ?: 'admin@exemple.com');
-        $email->setSubject('[Signalement] Nouveau signalement à traiter');
-        $email->setMessage(view('Emails/adminNewReport', [
-            'reporterId'  => $reporterId,
-            'journeyId'   => $journey['id'],
-            'description' => $description,
-        ]));
-
-        $email->send();
+        foreach ($admins as $admin) {
+            if (!$notifPrefModel->wantsNotif((int) $admin['id'], 'admin_report')) continue;
+            $adminId = (int) $admin['id'];
+            $mailer->sendHtml(
+                $admin['email'],
+                '[Signalement] Nouveau signalement à traiter',
+                view('Emails/adminNewReport', [
+                    'reporterId'     => $reporterId,
+                    'journeyId'      => $journey['id'],
+                    'description'    => $description,
+                    'prefLabel'      => NotificationPrefModel::PREFS['admin_report'],
+                    'unsubscribeUrl' => site_url('unsubscribe?uid=' . $adminId . '&pref=admin_report&token=' . UserModel::unsubscribeToken($adminId, 'admin_report')),
+                    'preferencesUrl' => site_url('profile/notifications'),
+                ])
+            );
+        }
     }
 }

--- a/app/Controllers/UserController.php
+++ b/app/Controllers/UserController.php
@@ -5,6 +5,7 @@ namespace App\Controllers;
 use App\Models\UserModel;
 use App\Models\RememberTokenModel;
 use App\Models\CityModel;
+use App\Models\NotificationPrefModel;
 use App\Libraries\MailerExample;
 use CodeIgniter\I18n\Time;
 use App\Models\CarModel;
@@ -18,13 +19,15 @@ class UserController extends BaseController
     private UserModel $userModel;
     private CityModel $cityModel;
     private CarModel $carModel;
+    private NotificationPrefModel $notifPrefModel;
     protected GeocodingService $geocodingService;
 
     public function __construct()
     {
-        $this->userModel = new UserModel();
-        $this->cityModel = new CityModel();
-        $this->carModel  = new CarModel();
+        $this->userModel      = new UserModel();
+        $this->cityModel      = new CityModel();
+        $this->carModel       = new CarModel();
+        $this->notifPrefModel = new NotificationPrefModel();
         $this->geocodingService = new GeocodingService();
         helper('cookie');
     }
@@ -361,6 +364,72 @@ class UserController extends BaseController
             'lastname'  => $lastname,
             'date'      => ucfirst(Time::now('Europe/Paris', 'fr_FR')->toLocalizedString('d MMMM yyyy à HH:mm')),
             'support'   => env('mailer.from'),
+        ]);
+    }
+
+    public function showNotifications(): string
+    {
+        $userId  = (int) session('user_id');
+        $isAdmin = (bool) session('isAdmin');
+
+        $prefLabels = $this->visiblePrefs($isAdmin);
+
+        return view('Profile/notifications', [
+            'title'      => 'Préférences de notifications',
+            'prefs'      => $this->notifPrefModel->getAllForUser($userId),
+            'prefLabels' => $prefLabels,
+        ]);
+    }
+
+    public function updateNotifications(): RedirectResponse
+    {
+        $userId    = (int) session('user_id');
+        $isAdmin   = (bool) session('isAdmin');
+        $submitted = array_intersect(
+            $this->request->getPost('prefs') ?? [],
+            array_keys($this->visiblePrefs($isAdmin))
+        );
+
+        $this->notifPrefModel->saveForUser($userId, $submitted, $this->visiblePrefs($isAdmin));
+
+        return redirect()->to(site_url('profile/notifications'))
+            ->with('success', 'Préférences mises à jour.');
+    }
+
+    private function visiblePrefs(bool $isAdmin): array
+    {
+        if ($isAdmin) {
+            return NotificationPrefModel::PREFS;
+        }
+        return array_filter(
+            NotificationPrefModel::PREFS,
+            fn($k) => !str_starts_with($k, 'admin_'),
+            ARRAY_FILTER_USE_KEY
+        );
+    }
+
+    public function unsubscribe(): string
+    {
+        $uid   = (int) $this->request->getGet('uid');
+        $pref  = (string) $this->request->getGet('pref');
+        $token = (string) $this->request->getGet('token');
+
+        if (!session()->get('isLoggedIn')) {
+            session()->set('redirect_url', site_url('profile/notifications'));
+        }
+
+        if (!$uid || !isset(NotificationPrefModel::PREFS[$pref]) || !$this->userModel->validateUnsubscribeToken($uid, $pref, $token)) {
+            return view('unsubscribe', ['success' => false, 'label' => '']);
+        }
+
+        $this->notifPrefModel->saveForUser($uid, array_filter(
+            array_keys(NotificationPrefModel::PREFS),
+            fn($k) => $k !== $pref && $this->notifPrefModel->wantsNotif($uid, $k)
+        ));
+
+        return view('unsubscribe', [
+            'success' => true,
+            'label'   => NotificationPrefModel::PREFS[$pref],
         ]);
     }
 }

--- a/app/Controllers/UserController.php
+++ b/app/Controllers/UserController.php
@@ -251,6 +251,22 @@ class UserController extends BaseController
             );
         }
 
+        // Envoi des emails de notification si l'adresse e-mail a changé
+        $newEmail = $data['email'];
+        if ($newEmail !== $user['email']) {
+            $mailer = new MailerExample();
+            $mailer->sendHtml(
+                $user['email'],
+                'Votre adresse e-mail a été modifiée',
+                $this->emailChangedOldEmail($user['firstname'], $user['lastname'], $newEmail)
+            );
+            $mailer->sendHtml(
+                $newEmail,
+                'Nouvelle adresse e-mail enregistrée',
+                $this->emailChangedNewEmail($user['firstname'], $user['lastname'])
+            );
+        }
+
         // Gestion de l'upload de l'avatar
         $avatar = $this->request->getFile('avatarProfile');
         if ($avatar && $avatar->isValid() && !$avatar->hasMoved()) {
@@ -297,6 +313,33 @@ class UserController extends BaseController
     private function passwordChangedEmail(string $firstname, string $lastname): string
     {
         return view('Emails/passwordChanged', [
+            'firstname' => $firstname,
+            'lastname'  => $lastname,
+            'date'      => ucfirst(Time::now('Europe/Paris', 'fr_FR')->toLocalizedString('d MMMM yyyy à HH:mm')),
+            'support'   => env('mailer.from'),
+        ]);
+    }
+
+    /**
+     * Construit le corps HTML de l'email envoyé à l'ancienne adresse lors d'un changement d'email
+     */
+    private function emailChangedOldEmail(string $firstname, string $lastname, string $newEmail): string
+    {
+        return view('Emails/emailChangedOld', [
+            'firstname' => $firstname,
+            'lastname'  => $lastname,
+            'newEmail'  => $newEmail,
+            'date'      => ucfirst(Time::now('Europe/Paris', 'fr_FR')->toLocalizedString('d MMMM yyyy à HH:mm')),
+            'support'   => env('mailer.from'),
+        ]);
+    }
+
+    /**
+     * Construit le corps HTML de l'email envoyé à la nouvelle adresse lors d'un changement d'email
+     */
+    private function emailChangedNewEmail(string $firstname, string $lastname): string
+    {
+        return view('Emails/emailChangedNew', [
             'firstname' => $firstname,
             'lastname'  => $lastname,
             'date'      => ucfirst(Time::now('Europe/Paris', 'fr_FR')->toLocalizedString('d MMMM yyyy à HH:mm')),

--- a/app/Database/Migrations/2026-06-18-100000_AddRadiusKmToJourneyRequest.php
+++ b/app/Database/Migrations/2026-06-18-100000_AddRadiusKmToJourneyRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class AddRadiusKmToJourneyRequest extends Migration
+{
+    public function up()
+    {
+        $this->forge->addColumn('journey_request', [
+            'radius_km' => [
+                'type'     => 'TINYINT',
+                'unsigned' => true,
+                'null'     => false,
+                'default'  => 10,
+                'after'    => 'seats',
+            ],
+        ]);
+    }
+
+    public function down()
+    {
+        $this->forge->dropColumn('journey_request', 'radius_km');
+    }
+}

--- a/app/Database/Migrations/2026-06-18-110000_ChangeRadiusKmToDecimalInJourneyRequest.php
+++ b/app/Database/Migrations/2026-06-18-110000_ChangeRadiusKmToDecimalInJourneyRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class ChangeRadiusKmToDecimalInJourneyRequest extends Migration
+{
+    public function up()
+    {
+        $this->forge->modifyColumn('journey_request', [
+            'radius_km' => [
+                'type'       => 'DECIMAL',
+                'constraint' => '4,1',
+                'null'       => false,
+                'default'    => 10.0,
+            ],
+        ]);
+    }
+
+    public function down()
+    {
+        $this->forge->modifyColumn('journey_request', [
+            'radius_km' => [
+                'type'     => 'TINYINT',
+                'unsigned' => true,
+                'null'     => false,
+                'default'  => 10,
+            ],
+        ]);
+    }
+}

--- a/app/Database/Migrations/2026-06-18-120000_AddEmailVerificationToUser.php
+++ b/app/Database/Migrations/2026-06-18-120000_AddEmailVerificationToUser.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class AddEmailVerificationToUser extends Migration
+{
+    public function up(): void
+    {
+        // Ajoute 'unverified' comme premier statut possible (avant 'pending')
+        $this->forge->modifyColumn('user', [
+            'status' => [
+                'type'       => 'ENUM',
+                'constraint' => ['unverified', 'pending', 'active', 'rejected'],
+                'default'    => 'unverified',
+                'null'       => false,
+            ],
+        ]);
+
+        $this->forge->addColumn('user', [
+            'email_token' => [
+                'type'       => 'VARCHAR',
+                'constraint' => 64,
+                'null'       => true,
+                'after'      => 'status',
+            ],
+            'email_token_expiry' => [
+                'type'  => 'DATETIME',
+                'null'  => true,
+                'after' => 'email_token',
+            ],
+        ]);
+    }
+
+    public function down(): void
+    {
+        $this->forge->dropColumn('user', ['email_token', 'email_token_expiry']);
+
+        $this->forge->modifyColumn('user', [
+            'status' => [
+                'type'       => 'ENUM',
+                'constraint' => ['pending', 'active', 'rejected'],
+                'default'    => 'pending',
+                'null'       => false,
+            ],
+        ]);
+    }
+}

--- a/app/Database/Migrations/2026-06-18-130000_CreateNotificationPrefTable.php
+++ b/app/Database/Migrations/2026-06-18-130000_CreateNotificationPrefTable.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class CreateNotificationPrefTable extends Migration
+{
+    public function up(): void
+    {
+        $this->forge->addField([
+            'user_id' => [
+                'type' => 'INT',
+                'null' => false,
+            ],
+            'pref' => [
+                'type'       => 'VARCHAR',
+                'constraint' => 50,
+                'null'       => false,
+            ],
+            'enabled' => [
+                'type'       => 'TINYINT',
+                'constraint' => 1,
+                'default'    => 1,
+                'null'       => false,
+            ],
+        ]);
+
+        $this->forge->addPrimaryKey(['user_id', 'pref']);
+        $this->forge->addForeignKey('user_id', 'user', 'id', 'CASCADE', 'CASCADE');
+        $this->forge->createTable('user_notification_pref');
+    }
+
+    public function down(): void
+    {
+        $this->forge->dropTable('user_notification_pref');
+    }
+}

--- a/app/Models/JourneyRequestModel.php
+++ b/app/Models/JourneyRequestModel.php
@@ -15,16 +15,17 @@ class JourneyRequestModel extends BaseModel
     protected $allowedFields = [
         'start_datetime',
         'seats',
+        'radius_km',
         'message',
         'user_id',
         'location_start_id',
-        'location_end_id'
-
+        'location_end_id',
     ];
 
     protected $validationRules = [
         'start_datetime'    => 'required|valid_date[Y-m-d H:i:s]|after_now',
         'seats'             => 'permit_empty|integer|greater_than_equal_to[1]|less_than_equal_to[8]',
+        'radius_km'         => 'permit_empty|numeric|greater_than_equal_to[0.1]|less_than_equal_to[200]',
         'message'           => 'permit_empty|max_length[2000]',
         'user_id'           => 'required|integer|is_not_unique[user.id]',
         'location_start_id' => 'required|integer|is_not_unique[location.id]',

--- a/app/Models/JourneyRequestModel.php
+++ b/app/Models/JourneyRequestModel.php
@@ -91,6 +91,33 @@ class JourneyRequestModel extends BaseModel
     }
 
     /**
+     * Récupère une demande avec ses coordonnées GPS et les infos du demandeur,
+     * sans restriction d'ownership — utilisé pour le matching côté service.
+     *
+     * @param  int        $id Identifiant de la demande
+     * @return array|null     Demande enrichie, ou null si introuvable
+     */
+    public function findWithCoordinatesById(int $id): ?array
+    {
+        return $this->select('journey_request.*,
+                u.email             as requester_email,
+                u.firstname         as requester_firstname,
+                loc_start.latitude  as start_lat,
+                loc_start.longitude as start_lng,
+                loc_end.latitude    as end_lat,
+                loc_end.longitude   as end_lng,
+                city_start.name     as city_start_name,
+                city_end.name       as city_end_name')
+            ->join('user u',             'u.id = journey_request.user_id')
+            ->join('location loc_start', 'loc_start.id = journey_request.location_start_id')
+            ->join('location loc_end',   'loc_end.id = journey_request.location_end_id')
+            ->join('city city_start',    'city_start.id = loc_start.city_id')
+            ->join('city city_end',      'city_end.id = loc_end.city_id')
+            ->where('journey_request.id', $id)
+            ->first();
+    }
+
+    /**
      * Récupère une demande de trajet avec toutes ses informations liées :
      * adresses et villes de départ/arrivée.
      *

--- a/app/Models/NotificationPrefModel.php
+++ b/app/Models/NotificationPrefModel.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Models;
+
+use CodeIgniter\Model;
+
+class NotificationPrefModel extends Model
+{
+    protected $table      = 'user_notification_pref';
+    protected $primaryKey = 'user_id';
+
+    protected $allowedFields = ['user_id', 'pref', 'enabled'];
+
+    public const PREFS = [
+        'booking_request'   => 'Nouvelle demande de réservation sur votre trajet',
+        'booking_accepted'  => 'Votre réservation a été acceptée',
+        'booking_rejected'  => 'Votre réservation a été refusée',
+        'booking_cancelled' => 'Un passager a annulé sa réservation',
+        'journey_cancelled' => 'Un trajet sur lequel vous êtes réservé a été annulé',
+        'journey_request'   => 'Un trajet correspond à votre demande de trajet',
+        'admin_registration' => 'Nouvelle demande d\'inscription à valider (administrateurs)',
+        'admin_report'      => 'Nouveau signalement à traiter (administrateurs)',
+    ];
+
+    /**
+     * Retourne true si l'utilisateur veut recevoir ce type de notification.
+     * Par défaut (ligne absente) = activé.
+     */
+    public function wantsNotif(int $userId, string $pref): bool
+    {
+        $row = $this->where('user_id', $userId)->where('pref', $pref)->first();
+        return $row === null || (bool) $row['enabled'];
+    }
+
+    /**
+     * Retourne toutes les préférences d'un utilisateur sous forme [pref => bool].
+     * Les prefs absentes sont considérées comme activées.
+     */
+    public function getAllForUser(int $userId): array
+    {
+        $rows = $this->where('user_id', $userId)->findAll();
+        $map  = array_column($rows, 'enabled', 'pref');
+
+        $result = [];
+        foreach (array_keys(self::PREFS) as $key) {
+            $result[$key] = isset($map[$key]) ? (bool) $map[$key] : true;
+        }
+        return $result;
+    }
+
+    /**
+     * Sauvegarde les préférences d'un utilisateur.
+     * $submitted  = slugs cochés dans le formulaire.
+     * $allowedMap = sous-ensemble de PREFS à traiter (par défaut tous).
+     *               Permet de ne pas écraser les prefs hors portée (ex: admin_* pour un user).
+     */
+    public function saveForUser(int $userId, array $submitted, array $allowedMap = self::PREFS): void
+    {
+        foreach (array_keys($allowedMap) as $key) {
+            $enabled  = in_array($key, $submitted, true) ? 1 : 0;
+            $existing = $this->where('user_id', $userId)->where('pref', $key)->first();
+
+            if ($existing) {
+                $this->where('user_id', $userId)->where('pref', $key)
+                     ->set('enabled', $enabled)->update();
+            } else {
+                $this->insert(['user_id' => $userId, 'pref' => $key, 'enabled' => $enabled]);
+            }
+        }
+    }
+}

--- a/app/Models/UserModel.php
+++ b/app/Models/UserModel.php
@@ -43,6 +43,8 @@ class UserModel extends BaseModel
         'reset_token',
         'reset_token_expiry',
         'role',
+        'email_token',
+        'email_token_expiry',
     ];
 
     // Règles de validation appliquées automatiquement avant chaque insertion
@@ -201,5 +203,20 @@ class UserModel extends BaseModel
     public function ban(int $userId): bool
     {
         return $this->update($userId, ['is_banned' => 1]);
+    }
+
+    public function setEmailToken(int $userId, string $rawToken, int $hours = 24): bool
+    {
+        return $this->update($userId, [
+            'email_token'        => hash('sha256', $rawToken),
+            'email_token_expiry' => date('Y-m-d H:i:s', strtotime("+{$hours} hour")),
+        ]);
+    }
+
+    public function findByValidEmailToken(string $rawToken)
+    {
+        return $this->where('email_token', hash('sha256', $rawToken))
+            ->where('email_token_expiry >', date('Y-m-d H:i:s'))
+            ->first();
     }
 }

--- a/app/Models/UserModel.php
+++ b/app/Models/UserModel.php
@@ -219,4 +219,14 @@ class UserModel extends BaseModel
             ->where('email_token_expiry >', date('Y-m-d H:i:s'))
             ->first();
     }
+
+    public static function unsubscribeToken(int $userId, string $pref): string
+    {
+        return hash_hmac('sha256', $userId . ':' . $pref, env('encryption.key', 'kenweturi'));
+    }
+
+    public function validateUnsubscribeToken(int $userId, string $pref, string $token): bool
+    {
+        return hash_equals(self::unsubscribeToken($userId, $pref), $token);
+    }
 }

--- a/app/Services/BookingService.php
+++ b/app/Services/BookingService.php
@@ -8,6 +8,8 @@ use App\Services\JourneyService;
 
 use App\Models\JourneyModel;
 use App\Models\BookingModel;
+use App\Models\NotificationPrefModel;
+use App\Models\UserModel;
 
 use App\Exceptions\BookingAlreadyAcceptedException;
 use App\Exceptions\BookingNotAssignedToDriverException;
@@ -23,13 +25,14 @@ class BookingService
 
     protected JourneyModel $journeyModel;
     protected BookingModel $bookingModel;
+    protected NotificationPrefModel $notifPrefModel;
 
     public function __construct()
     {
-        $this->journeyService       = new JourneyService();
-
-        $this->journeyModel         = new JourneyModel();
-        $this->bookingModel         = new BookingModel();
+        $this->journeyService  = new JourneyService();
+        $this->journeyModel    = new JourneyModel();
+        $this->bookingModel    = new BookingModel();
+        $this->notifPrefModel  = new NotificationPrefModel();
     }
 
     public function accept(int $bookingId,int $driverId):void{
@@ -61,9 +64,14 @@ class BookingService
 
     }
 
-    public function confirmToPassenger(int $bookingId, int $driverId){
+    public function confirmToPassenger(int $bookingId, int $driverId): void
+    {
+        $booking     = $this->bookingModel->findWithDetails($bookingId, $driverId);
+        $passengerId = (int) $booking['user_id'];
 
-        $booking = $this->bookingModel->findWithDetails($bookingId, $driverId);
+        if (!$this->notifPrefModel->wantsNotif($passengerId, 'booking_accepted')) {
+            return;
+        }
 
         $date = date('d/m/Y', strtotime($booking['start_datetime'])) . ' à ' . date('H:i', strtotime($booking['start_datetime']));
 
@@ -78,9 +86,11 @@ class BookingService
                 'cityStart'       => $booking['city_start_name'],
                 'cityEnd'         => $booking['city_end_name'],
                 'date'            => $date,
+                'prefLabel'       => NotificationPrefModel::PREFS['booking_accepted'],
+                'unsubscribeUrl'  => site_url('unsubscribe?uid=' . $passengerId . '&pref=booking_accepted&token=' . UserModel::unsubscribeToken($passengerId, 'booking_accepted')),
+                'preferencesUrl'  => site_url('profile/notifications'),
             ])
         );
-
     }
 
     public function getDetails(int $id, int $userId): array

--- a/app/Services/JourneyService.php
+++ b/app/Services/JourneyService.php
@@ -12,6 +12,8 @@ use App\Models\StageModel;
 use App\Models\CityModel;
 use App\Models\CarModel;
 use App\Models\BookingModel;
+use App\Models\NotificationPrefModel;
+use App\Models\UserModel;
 
 use App\Exceptions\ExternalApiException;
 use App\Exceptions\ModelValidationException;
@@ -48,6 +50,7 @@ class JourneyService
 
     protected RoutingService $routingService;
     protected GeocodingService $geocodingService;
+    protected NotificationPrefModel $notifPrefModel;
 
     protected MailerExample $mailer;
 
@@ -64,6 +67,7 @@ class JourneyService
         $this->cityModel            = new CityModel();
         $this->carModel             = new CarModel();
         $this->bookingModel         = new BookingModel();
+        $this->notifPrefModel       = new NotificationPrefModel();
 
         $this->routingService       = new RoutingService();
         $this->geocodingService     = new GeocodingService();
@@ -175,6 +179,9 @@ class JourneyService
             }
 
             // --- Envoi du mail
+            $requesterId = (int) $request['user_id'];
+            if (!$this->notifPrefModel->wantsNotif($requesterId, 'journey_request')) continue;
+
             $date = date('d/m/Y', strtotime($journey['start_datetime']))
                   . ' à ' . date('H:i', strtotime($journey['start_datetime']));
 
@@ -182,11 +189,14 @@ class JourneyService
                 $request['requester_email'],
                 'Un trajet correspond à votre demande !',
                 view('Emails/journeyRequestMatch', [
-                    'firstname'  => $request['requester_firstname'],
-                    'cityStart'  => $request['city_start_name'],
-                    'cityEnd'    => $request['city_end_name'],
-                    'date'       => $date,
-                    'journeyUrl' => site_url('journeys/' . $journeyId),
+                    'firstname'      => $request['requester_firstname'],
+                    'cityStart'      => $request['city_start_name'],
+                    'cityEnd'        => $request['city_end_name'],
+                    'date'           => $date,
+                    'journeyUrl'     => site_url('journeys/' . $journeyId),
+                    'prefLabel'      => NotificationPrefModel::PREFS['journey_request'],
+                    'unsubscribeUrl' => site_url('unsubscribe?uid=' . $requesterId . '&pref=journey_request&token=' . UserModel::unsubscribeToken($requesterId, 'journey_request')),
+                    'preferencesUrl' => site_url('profile/notifications'),
                 ])
             );
         }
@@ -233,6 +243,9 @@ class JourneyService
                 if ($diff > 1800) continue;
             }
 
+            $requesterId = (int) $request['user_id'];
+            if (!$this->notifPrefModel->wantsNotif($requesterId, 'journey_request')) continue;
+
             $date = date('d/m/Y', strtotime($journey['start_datetime']))
                   . ' à ' . date('H:i', strtotime($journey['start_datetime']));
 
@@ -240,11 +253,14 @@ class JourneyService
                 $request['requester_email'],
                 'Un trajet correspond à votre demande !',
                 view('Emails/journeyRequestMatch', [
-                    'firstname'  => $request['requester_firstname'],
-                    'cityStart'  => $request['city_start_name'],
-                    'cityEnd'    => $request['city_end_name'],
-                    'date'       => $date,
-                    'journeyUrl' => site_url('journeys/' . $journey['id']),
+                    'firstname'      => $request['requester_firstname'],
+                    'cityStart'      => $request['city_start_name'],
+                    'cityEnd'        => $request['city_end_name'],
+                    'date'           => $date,
+                    'journeyUrl'     => site_url('journeys/' . $journey['id']),
+                    'prefLabel'      => NotificationPrefModel::PREFS['journey_request'],
+                    'unsubscribeUrl' => site_url('unsubscribe?uid=' . $requesterId . '&pref=journey_request&token=' . UserModel::unsubscribeToken($requesterId, 'journey_request')),
+                    'preferencesUrl' => site_url('profile/notifications'),
                 ])
             );
         }
@@ -297,24 +313,30 @@ class JourneyService
     public function notifyCancelledJourney(array $journey): void
     {
         $bookings = $this->bookingModel
-            ->select('user.email, user.firstname')
+            ->select('booking.user_id as passenger_id, user.email, user.firstname')
             ->join('user', 'user.id = booking.user_id')
             ->where('booking.journey_id', $journey['id'])
             ->where('booking.status', 'accepted')
             ->findAll();
-        
+
+        $date = date('d/m/Y', strtotime($journey['start_datetime']))
+            . ' à ' . date('H:i', strtotime($journey['start_datetime']));
+
         foreach ($bookings as $booking) {
-            $date = date('d/m/Y', strtotime($journey['start_datetime']))
-                . ' à ' . date('H:i', strtotime($journey['start_datetime']));
+            $passengerId = (int) $booking['passenger_id'];
+            if (!$this->notifPrefModel->wantsNotif($passengerId, 'journey_cancelled')) continue;
 
             $this->mailer->sendHtml(
                 $booking['email'],
                 'Votre trajet a été annulé',
                 view('Emails/journeyCancelled', [
-                    'firstname' => $booking['firstname'],
-                    'cityStart' => $journey['city_start_name'],
-                    'cityEnd'   => $journey['city_end_name'],
-                    'date'      => $date,
+                    'firstname'      => $booking['firstname'],
+                    'cityStart'      => $journey['city_start_name'],
+                    'cityEnd'        => $journey['city_end_name'],
+                    'date'           => $date,
+                    'prefLabel'      => NotificationPrefModel::PREFS['journey_cancelled'],
+                    'unsubscribeUrl' => site_url('unsubscribe?uid=' . $passengerId . '&pref=journey_cancelled&token=' . UserModel::unsubscribeToken($passengerId, 'journey_cancelled')),
+                    'preferencesUrl' => site_url('profile/notifications'),
                 ])
             );
         }

--- a/app/Services/JourneyService.php
+++ b/app/Services/JourneyService.php
@@ -192,6 +192,64 @@ class JourneyService
         }
     }
 
+    /**
+     * Recherche les trajets existants compatibles avec une demande de trajet
+     * (typiquement après modification) et envoie un email au demandeur pour chaque match.
+     *
+     * Symétrique de notifyMatchingRequests : ici on fixe la demande et on itère
+     * sur les trajets actifs pour trouver ceux dont le tracé passe à moins de 10 km
+     * du départ et de l'arrivée de la demande, dans la bonne direction, et dans
+     * un créneau de ±30 minutes.
+     *
+     * @param  int $requestId     Identifiant de la demande mise à jour
+     * @param  int $requestUserId Identifiant du demandeur (exclu des trajets à matcher)
+     * @return void
+     */
+    public function notifyMatchingJourneys(int $requestId, int $requestUserId): void
+    {
+        $request = $this->journeyRequestModel->findWithCoordinatesById($requestId);
+        if (!$request) return;
+
+        $journeys = array_filter(
+            $this->journeyModel->findAllWithFilters([]),
+            fn($j) => (int) $j['user_id'] !== $requestUserId
+        );
+
+        if (empty($journeys)) return;
+
+        $start = ['lat' => (float) $request['start_lat'], 'lon' => (float) $request['start_lng']];
+        $end   = ['lat' => (float) $request['end_lat'],   'lon' => (float) $request['end_lng']];
+
+        foreach ($journeys as $journey) {
+            if (empty($journey['track_geojson'])) continue;
+
+            $points = $this->geoService->parseTrackPointsFromGeoJson($journey['track_geojson']);
+            if (empty($points)) continue;
+
+            if (!$this->geoService->matchesTrackPoints($points, $start, $end)) continue;
+
+            if (!empty($request['start_datetime'])) {
+                $diff = abs(strtotime($journey['start_datetime']) - strtotime($request['start_datetime']));
+                if ($diff > 1800) continue;
+            }
+
+            $date = date('d/m/Y', strtotime($journey['start_datetime']))
+                  . ' à ' . date('H:i', strtotime($journey['start_datetime']));
+
+            $this->mailer->sendHtml(
+                $request['requester_email'],
+                'Un trajet correspond à votre demande !',
+                view('Emails/journeyRequestMatch', [
+                    'firstname'  => $request['requester_firstname'],
+                    'cityStart'  => $request['city_start_name'],
+                    'cityEnd'    => $request['city_end_name'],
+                    'date'       => $date,
+                    'journeyUrl' => site_url('journeys/' . $journey['id']),
+                ])
+            );
+        }
+    }
+
     public function getMaxSeatsForCar(int $carId, int $userId): int
     {
         if ($carId <= 0) return self::ABSOLUTE_MAX_SEATS;

--- a/app/Services/JourneyService.php
+++ b/app/Services/JourneyService.php
@@ -164,7 +164,7 @@ class JourneyService
             $start = ['lat' => (float) $request['start_lat'], 'lon' => (float) $request['start_lng']];
             $end   = ['lat' => (float) $request['end_lat'],   'lon' => (float) $request['end_lng']];
 
-            if (!$this->geoService->matchesTrackPoints($points, $start, $end)) {
+            if (!$this->geoService->matchesTrackPoints($points, $start, $end, (float) ($request['radius_km'] ?? 10))) {
                 continue;
             }
 
@@ -226,7 +226,7 @@ class JourneyService
             $points = $this->geoService->parseTrackPointsFromGeoJson($journey['track_geojson']);
             if (empty($points)) continue;
 
-            if (!$this->geoService->matchesTrackPoints($points, $start, $end)) continue;
+            if (!$this->geoService->matchesTrackPoints($points, $start, $end, (float) ($request['radius_km'] ?? 10))) continue;
 
             if (!empty($request['start_datetime'])) {
                 $diff = abs(strtotime($journey['start_datetime']) - strtotime($request['start_datetime']));

--- a/app/Views/Dashboard/dashboardJourneys.php
+++ b/app/Views/Dashboard/dashboardJourneys.php
@@ -69,9 +69,9 @@
                                 <span class="text-xs text-danger font-semibold bg-danger/10 px-2 py-0.5 rounded-full">Annulé</span>
                             </div>
                         <?php elseif ($filter !== 'past'): ?>
-                            <div class="journey-checkbox absolute top-1.5 right-3 z-10 hidden w-5 h-5 flex items-center justify-center">
+                            <div class="journey-checkbox absolute top-3 right-3 z-10 hidden">
                                 <input type="checkbox" name="journey_ids[]" value="<?= esc($journey['id']) ?>"
-                                    class="w-5 h-5 rounded border-action/30 text-action focus:ring-action/40 cursor-pointer">
+                                    class="appearance-none w-5 h-5 rounded-full border-2 border-action/40 bg-paper checked:bg-action checked:border-action cursor-pointer transition-colors focus:ring-0">
                             </div>
                         <?php endif ?>
 
@@ -125,13 +125,13 @@
         <!-- Barre d'action flottante (mode sélection) -->
         <div class="grid items-center -mt-4">
             <div id="selectionBar" class="hidden sticky bottom-4 z-50 flex justify-end pointer-events-none col-start-1 row-start-1">
-                <div class="bg-ink text-paper rounded-full px-5 py-3 shadow-xl flex items-center gap-4 pointer-events-auto">
-                    <span id="selectionCount" class="text-sm font-medium">0 sélectionné</span>
+                <div class="bg-surface border border-action/20 rounded-full px-5 py-3 shadow-xl flex items-center gap-4 pointer-events-auto">
+                    <span id="selectionCount" class="text-sm font-medium text-ink">0 sélectionné</span>
                     <button type="button" id="cancelSelectedBtn"
                         class="bg-danger text-paper text-sm font-semibold rounded-full px-4 py-1.5 hover:opacity-90 transition-opacity">
                         Annuler
                     </button>
-                    <button type="button" id="exitSelectionBtn" class="text-paper/60 hover:text-paper text-sm transition-colors">
+                    <button type="button" id="exitSelectionBtn" class="text-ink/40 hover:text-ink text-sm transition-colors">
                         <i class="fa-solid fa-xmark"></i>
                     </button>
                 </div>

--- a/app/Views/Emails/_notifFooter.php
+++ b/app/Views/Emails/_notifFooter.php
@@ -1,0 +1,16 @@
+<?php
+/** @var string $prefLabel */
+/** @var string $unsubscribeUrl */
+/** @var string $preferencesUrl */
+?>
+                    <!-- Unsubscribe -->
+                    <tr>
+                        <td style="background-color:#0d1520;padding:12px 40px;border-top:1px solid #1e2e40;">
+                            <p style="margin:0;font-size:11px;color:#3d5570;line-height:1.8;text-align:center;">
+                                Vous recevez cet email car vous avez activé les notifications &laquo;&nbsp;<?= esc($prefLabel) ?>&nbsp;&raquo;.<br>
+                                <a href="<?= esc($unsubscribeUrl) ?>" style="color:#93b8d8;text-decoration:underline;">Se désabonner de ce type</a>
+                                &nbsp;·&nbsp;
+                                <a href="<?= esc($preferencesUrl) ?>" style="color:#93b8d8;text-decoration:underline;">Gérer toutes mes préférences</a>
+                            </p>
+                        </td>
+                    </tr>

--- a/app/Views/Emails/adminNewReport.php
+++ b/app/Views/Emails/adminNewReport.php
@@ -2,6 +2,9 @@
 /** @var int    $reporterId */
 /** @var int    $journeyId */
 /** @var string $description */
+/** @var string $prefLabel */
+/** @var string $unsubscribeUrl */
+/** @var string $preferencesUrl */
 ?>
 <!DOCTYPE html>
 <html lang="fr">
@@ -61,6 +64,8 @@
 
                         </td>
                     </tr>
+
+                    <?= view('Emails/_notifFooter', compact('prefLabel', 'unsubscribeUrl', 'preferencesUrl')) ?>
 
                     <!-- Footer -->
                     <tr>

--- a/app/Views/Emails/bookingAccepted.php
+++ b/app/Views/Emails/bookingAccepted.php
@@ -5,6 +5,9 @@
 /** @var string $cityStart */
 /** @var string $cityEnd */
 /** @var string $date */
+/** @var string $prefLabel */
+/** @var string $unsubscribeUrl */
+/** @var string $preferencesUrl */
 ?>
 <!DOCTYPE html>
 <html lang="fr">
@@ -62,6 +65,8 @@
 
                         </td>
                     </tr>
+
+                    <?= view('Emails/_notifFooter', compact('prefLabel', 'unsubscribeUrl', 'preferencesUrl')) ?>
 
                     <!-- Footer -->
                     <tr>

--- a/app/Views/Emails/bookingCancelled.php
+++ b/app/Views/Emails/bookingCancelled.php
@@ -5,6 +5,9 @@
 /** @var string $cityStart */
 /** @var string $cityEnd */
 /** @var string $date */
+/** @var string $prefLabel */
+/** @var string $unsubscribeUrl */
+/** @var string $preferencesUrl */
 ?>
 <!DOCTYPE html>
 <html lang="fr">
@@ -66,6 +69,8 @@
 
                         </td>
                     </tr>
+
+                    <?= view('Emails/_notifFooter', compact('prefLabel', 'unsubscribeUrl', 'preferencesUrl')) ?>
 
                     <!-- Footer -->
                     <tr>

--- a/app/Views/Emails/bookingRejected.php
+++ b/app/Views/Emails/bookingRejected.php
@@ -3,6 +3,9 @@
 /** @var string $cityStart */
 /** @var string $cityEnd */
 /** @var string $date */
+/** @var string $prefLabel */
+/** @var string $unsubscribeUrl */
+/** @var string $preferencesUrl */
 ?>
 <!DOCTYPE html>
 <html lang="fr">
@@ -64,6 +67,8 @@
 
                         </td>
                     </tr>
+
+                    <?= view('Emails/_notifFooter', compact('prefLabel', 'unsubscribeUrl', 'preferencesUrl')) ?>
 
                     <!-- Footer -->
                     <tr>

--- a/app/Views/Emails/bookingRequest.php
+++ b/app/Views/Emails/bookingRequest.php
@@ -5,6 +5,9 @@
 /** @var string $cityStart */
 /** @var string $cityEnd */
 /** @var string $date */
+/** @var string $prefLabel */
+/** @var string $unsubscribeUrl */
+/** @var string $preferencesUrl */
 ?>
 <!DOCTYPE html>
 <html lang="fr">
@@ -66,6 +69,8 @@
 
                         </td>
                     </tr>
+
+                    <?= view('Emails/_notifFooter', compact('prefLabel', 'unsubscribeUrl', 'preferencesUrl')) ?>
 
                     <!-- Footer -->
                     <tr>

--- a/app/Views/Emails/emailChangedNew.php
+++ b/app/Views/Emails/emailChangedNew.php
@@ -1,0 +1,62 @@
+<?php
+/** @var string $firstname */
+/** @var string $lastname */
+/** @var string $date */
+/** @var string $support */
+?>
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Nouvelle adresse e-mail confirmée</title>
+</head>
+<body style="margin:0;padding:0;background-color:#111a26;font-family:'Helvetica Neue',Arial,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background-color:#111a26;padding:40px 16px;">
+    <tr>
+      <td align="center">
+        <table width="100%" cellpadding="0" cellspacing="0" style="max-width:560px;">
+
+          <!-- Header -->
+          <tr>
+            <td style="background-color:#1a3a5c;border-radius:12px 12px 0 0;padding:28px 40px;text-align:center;">
+              <span style="font-size:22px;font-weight:700;color:#ffffff;letter-spacing:-0.3px;">Ken</span><span style="font-size:22px;font-weight:700;color:#F2860E;letter-spacing:-0.3px;">weturi</span>
+            </td>
+          </tr>
+
+          <!-- Body -->
+          <tr>
+            <td style="background-color:#16222e;padding:40px;">
+
+              <p style="margin:0 0 8px;font-size:20px;font-weight:700;color:#ffffff;letter-spacing:-0.2px;">
+                Nouvelle adresse e-mail enregistrée
+              </p>
+              <p style="margin:0 0 28px;font-size:14px;color:#93b8d8;line-height:1.6;">
+                Bonjour <?= esc($firstname) ?> <?= esc($lastname) ?>,
+              </p>
+              <p style="margin:0 0 28px;font-size:15px;color:#93b8d8;line-height:1.6;">
+                Cette adresse e-mail est maintenant associée à votre compte Kenweturi depuis le <strong style="color:#ffffff;"><?= esc($date) ?></strong>. Vous recevrez dorénavant toutes les communications sur cette adresse.
+              </p>
+              <p style="margin:0;font-size:15px;color:#93b8d8;line-height:1.6;">
+                Si vous n'êtes pas à l'origine de cette modification, contactez-nous immédiatement à
+                <a href="mailto:<?= esc($support) ?>" style="color:#378ADD;text-decoration:none;"><?= esc($support) ?></a>.
+              </p>
+
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="background-color:#111a26;border-radius:0 0 12px 12px;padding:24px 40px;border-top:1px solid #1a3a5c;">
+              <p style="margin:0;font-size:12px;color:#555;line-height:1.6;text-align:center;">
+                Cet email a été envoyé automatiquement, merci de ne pas y répondre directement.
+              </p>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/app/Views/Emails/emailChangedOld.php
+++ b/app/Views/Emails/emailChangedOld.php
@@ -1,0 +1,66 @@
+<?php
+/** @var string $firstname */
+/** @var string $lastname */
+/** @var string $newEmail */
+/** @var string $date */
+/** @var string $support */
+?>
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Adresse e-mail modifiée</title>
+</head>
+<body style="margin:0;padding:0;background-color:#111a26;font-family:'Helvetica Neue',Arial,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background-color:#111a26;padding:40px 16px;">
+    <tr>
+      <td align="center">
+        <table width="100%" cellpadding="0" cellspacing="0" style="max-width:560px;">
+
+          <!-- Header -->
+          <tr>
+            <td style="background-color:#1a3a5c;border-radius:12px 12px 0 0;padding:28px 40px;text-align:center;">
+              <span style="font-size:22px;font-weight:700;color:#ffffff;letter-spacing:-0.3px;">Ken</span><span style="font-size:22px;font-weight:700;color:#F2860E;letter-spacing:-0.3px;">weturi</span>
+            </td>
+          </tr>
+
+          <!-- Body -->
+          <tr>
+            <td style="background-color:#16222e;padding:40px;">
+
+              <p style="margin:0 0 8px;font-size:20px;font-weight:700;color:#ffffff;letter-spacing:-0.2px;">
+                Adresse e-mail modifiée
+              </p>
+              <p style="margin:0 0 28px;font-size:14px;color:#93b8d8;line-height:1.6;">
+                Bonjour <?= esc($firstname) ?> <?= esc($lastname) ?>,
+              </p>
+              <p style="margin:0 0 20px;font-size:15px;color:#93b8d8;line-height:1.6;">
+                Nous vous informons que l'adresse e-mail associée à votre compte Kenweturi a été modifiée le <strong style="color:#ffffff;"><?= esc($date) ?></strong>.
+              </p>
+              <p style="margin:0 0 28px;font-size:15px;color:#93b8d8;line-height:1.6;">
+                La nouvelle adresse enregistrée est : <strong style="color:#ffffff;"><?= esc($newEmail) ?></strong>
+              </p>
+              <p style="margin:0;font-size:15px;color:#93b8d8;line-height:1.6;">
+                Si vous n'êtes pas à l'origine de cette modification, contactez-nous immédiatement à
+                <a href="mailto:<?= esc($support) ?>" style="color:#378ADD;text-decoration:none;"><?= esc($support) ?></a>.
+              </p>
+
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="background-color:#111a26;border-radius:0 0 12px 12px;padding:24px 40px;border-top:1px solid #1a3a5c;">
+              <p style="margin:0;font-size:12px;color:#555;line-height:1.6;text-align:center;">
+                Cet email a été envoyé automatiquement, merci de ne pas y répondre directement.
+              </p>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/app/Views/Emails/emailVerification.php
+++ b/app/Views/Emails/emailVerification.php
@@ -1,0 +1,79 @@
+<?php
+/** @var string $firstname */
+/** @var string $verifyLink */
+?>
+<!DOCTYPE html>
+<html lang="fr">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Confirmez votre adresse email</title>
+</head>
+
+<body style="margin:0;padding:0;background-color:#111a26;font-family:'Helvetica Neue',Arial,sans-serif;">
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color:#111a26;padding:40px 16px;">
+        <tr>
+            <td align="center">
+                <table width="100%" cellpadding="0" cellspacing="0" style="max-width:560px;">
+
+                    <!-- Header -->
+                    <tr>
+                        <td style="background-color:#1a3a5c;border-radius:12px 12px 0 0;padding:28px 40px;text-align:center;">
+                            <span style="font-size:22px;font-weight:700;color:#ffffff;letter-spacing:-0.3px;">Ken</span><span style="font-size:22px;font-weight:700;color:#F2860E;letter-spacing:-0.3px;">weturi</span>
+                        </td>
+                    </tr>
+
+                    <!-- Body -->
+                    <tr>
+                        <td style="background-color:#16222e;padding:40px;">
+
+                            <p style="margin:0 0 24px;font-size:20px;font-weight:700;color:#ffffff;letter-spacing:-0.2px;">
+                                Bienvenue, <?= esc($firstname) ?> !
+                            </p>
+
+                            <p style="margin:0 0 20px;font-size:15px;color:#93b8d8;line-height:1.6;">
+                                Merci pour votre inscription sur <strong style="color:#ffffff;">Kenweturi</strong>. Pour finaliser votre demande, veuillez d'abord confirmer votre adresse email en cliquant sur le bouton ci-dessous.
+                            </p>
+
+                            <p style="margin:0 0 32px;font-size:15px;color:#93b8d8;line-height:1.6;">
+                                Ce lien est valable <strong style="color:#ffffff;">24 heures</strong>. Passé ce délai, vous devrez vous réinscrire.
+                            </p>
+
+                            <!-- CTA -->
+                            <table cellpadding="0" cellspacing="0" width="100%">
+                                <tr>
+                                    <td align="center" style="padding-bottom:24px;">
+                                        <a href="<?= $verifyLink ?>"
+                                            style="display:inline-block;background-color:#D85A30;color:#ffffff;font-size:15px;font-weight:700;text-decoration:none;padding:14px 36px;border-radius:8px;letter-spacing:0.1px;">
+                                            Confirmer mon adresse email
+                                        </a>
+                                    </td>
+                                </tr>
+                            </table>
+
+                            <p style="margin:0;font-size:13px;color:#556678;line-height:1.6;">
+                                Si le bouton ne fonctionne pas, copiez ce lien dans votre navigateur :<br>
+                                <span style="color:#93b8d8;word-break:break-all;"><?= $verifyLink ?></span>
+                            </p>
+
+                        </td>
+                    </tr>
+
+                    <!-- Footer -->
+                    <tr>
+                        <td style="background-color:#111a26;border-radius:0 0 12px 12px;padding:24px 40px;border-top:1px solid #1a3a5c;">
+                            <p style="margin:0;font-size:12px;color:#555;line-height:1.6;text-align:center;">
+                                Si vous n'êtes pas à l'origine de cette inscription, ignorez cet email.<br>
+                                <span style="color:#93b8d8;">L'équipe Kenweturi</span>
+                            </p>
+                        </td>
+                    </tr>
+
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+
+</html>

--- a/app/Views/Emails/journeyCancelled.php
+++ b/app/Views/Emails/journeyCancelled.php
@@ -3,6 +3,9 @@
 /** @var string $cityStart */
 /** @var string $cityEnd */
 /** @var string $date */
+/** @var string $prefLabel */
+/** @var string $unsubscribeUrl */
+/** @var string $preferencesUrl */
 ?>
 <!DOCTYPE html>
 <html lang="fr">
@@ -40,6 +43,8 @@
             </p>
         </td>
     </tr>
+    <?= view('Emails/_notifFooter', compact('prefLabel', 'unsubscribeUrl', 'preferencesUrl')) ?>
+
     <!-- Footer -->
     <tr>
         <td style="background-color:#111a26;border-radius:0 0 12px 12px;padding:24px 40px;border-top:1px solid #1a3a5c;">

--- a/app/Views/Emails/journeyRequestMatch.php
+++ b/app/Views/Emails/journeyRequestMatch.php
@@ -4,6 +4,9 @@
 /** @var string $cityEnd */
 /** @var string $date */
 /** @var string $journeyUrl */
+/** @var string $prefLabel */
+/** @var string $unsubscribeUrl */
+/** @var string $preferencesUrl */
 ?>
 <!DOCTYPE html>
 <html lang="fr">
@@ -55,6 +58,8 @@
                             </table>
                         </td>
                     </tr>
+
+                    <?= view('Emails/_notifFooter', compact('prefLabel', 'unsubscribeUrl', 'preferencesUrl')) ?>
 
                     <!-- Footer -->
                     <tr>

--- a/app/Views/Emails/newRegistration.php
+++ b/app/Views/Emails/newRegistration.php
@@ -2,6 +2,9 @@
 /** @var string $firstname */
 /** @var string $lastname */
 /** @var string $email */
+/** @var string $prefLabel */
+/** @var string $unsubscribeUrl */
+/** @var string $preferencesUrl */
 ?>
 <!DOCTYPE html>
 <html lang="fr">
@@ -59,6 +62,8 @@
 
                         </td>
                     </tr>
+
+                    <?= view('Emails/_notifFooter', compact('prefLabel', 'unsubscribeUrl', 'preferencesUrl')) ?>
 
                     <!-- Footer -->
                     <tr>

--- a/app/Views/JourneyRequests/journeyRequestEdit.php
+++ b/app/Views/JourneyRequests/journeyRequestEdit.php
@@ -1,3 +1,8 @@
+<?php
+/** @var string     $title */
+/** @var array      $journeyRequest */
+/** @var string|null $back */
+?>
 <?= view('partials/head', [
   'extraCss' => [
     'https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css',
@@ -78,6 +83,68 @@
         </div>
 
       </div>
+
+      <!-- Rayon -->
+      <?php
+        $initRadius = (float) old('radius_km', $journeyRequest['radius_km'] ?? 10);
+        $presets    = [5, 10];
+        $isCustom   = !in_array($initRadius, $presets);
+      ?>
+      <div class="mt-5 pt-5 border-t border-action/10">
+        <label class="text-ink/50 text-xs font-medium mb-2 block">Rayon de recherche autour de mes adresses</label>
+        <div class="flex gap-2 flex-wrap items-center">
+          <?php foreach ($presets as $km): ?>
+            <button type="button" data-radius="<?= $km ?>"
+              class="radius-pill border rounded-lg px-4 py-2 text-sm font-medium transition-colors <?= !$isCustom && $initRadius === $km ? 'bg-action text-ink border-action' : 'border-action/20 text-ink/50 hover:border-action/50 hover:text-ink' ?>">
+              <?= $km ?> km
+            </button>
+          <?php endforeach ?>
+          <div class="radius-custom-pill flex items-center border rounded-lg px-3 py-2 gap-1 transition-colors <?= $isCustom ? 'bg-action border-action' : 'border-action/20 hover:border-action/50' ?>">
+            <input type="number" id="customRadiusInput" min="0.1" max="200" step="0.1" placeholder="—"
+              value="<?= $isCustom ? $initRadius : '' ?>"
+              class="w-10 bg-transparent text-sm font-medium outline-none placeholder:text-ink/30 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none <?= $isCustom ? 'text-ink' : 'text-ink/50' ?>">
+            <span class="text-sm font-medium transition-colors <?= $isCustom ? 'text-ink' : 'text-ink/50' ?>">km</span>
+          </div>
+          <input type="hidden" name="radius_km" id="radiusKmInput" value="<?= esc($initRadius) ?>">
+        </div>
+        <p class="mt-2 text-ink/30 text-xs">Astuce : 0.5 = 500 m, 0.1 = 100 m</p>
+      </div>
+      <script>
+      (function() {
+        const pills  = document.querySelectorAll('.radius-pill');
+        const cpill  = document.querySelector('.radius-custom-pill');
+        const cinput = document.getElementById('customRadiusInput');
+        const hidden = document.getElementById('radiusKmInput');
+        const on     = ['bg-action', 'text-ink', 'border-action'];
+        const off    = ['border-action/20', 'text-ink/50'];
+
+        function activatePreset(btn) {
+          pills.forEach(p => { p.classList.remove(...on); p.classList.add(...off); });
+          btn.classList.add(...on); btn.classList.remove(...off);
+          cpill.classList.remove(...on); cpill.classList.add('border-action/20');
+          cinput.classList.remove('text-ink'); cinput.classList.add('text-ink/50');
+          cinput.value = '';
+        }
+
+        function activateCustom() {
+          pills.forEach(p => { p.classList.remove(...on); p.classList.add(...off); });
+          cpill.classList.add(...on); cpill.classList.remove('border-action/20');
+          cinput.classList.add('text-ink'); cinput.classList.remove('text-ink/50');
+        }
+
+        pills.forEach(p => p.addEventListener('click', () => {
+          activatePreset(p);
+          hidden.value = p.dataset.radius;
+        }));
+
+        cinput.addEventListener('focus', activateCustom);
+        cinput.addEventListener('input', () => {
+          activateCustom();
+          if (cinput.value) hidden.value = cinput.value;
+        });
+      })();
+      </script>
+
     </div>
 
     <!-- Date & heure -->

--- a/app/Views/JourneyRequests/journeyRequestEdit.php
+++ b/app/Views/JourneyRequests/journeyRequestEdit.php
@@ -86,8 +86,8 @@
 
       <!-- Rayon -->
       <?php
-        $initRadius = (float) old('radius_km', $journeyRequest['radius_km'] ?? 10);
-        $presets    = [5, 10];
+        $initRadius = (float) old('radius_km', $journeyRequest['radius_km'] ?? 1);
+        $presets    = [1, 5, 10];
         $isCustom   = !in_array($initRadius, $presets);
       ?>
       <div class="mt-5 pt-5 border-t border-action/10">
@@ -95,7 +95,7 @@
         <div class="flex gap-2 flex-wrap items-center">
           <?php foreach ($presets as $km): ?>
             <button type="button" data-radius="<?= $km ?>"
-              class="radius-pill border rounded-lg px-4 py-2 text-sm font-medium transition-colors <?= !$isCustom && $initRadius === $km ? 'bg-action text-ink border-action' : 'border-action/20 text-ink/50 hover:border-action/50 hover:text-ink' ?>">
+              class="radius-pill border rounded-lg px-4 py-2 text-sm font-medium transition-colors <?= !$isCustom && $initRadius == $km ? 'bg-action text-ink border-action' : 'border-action/20 text-ink/50 hover:border-action/50 hover:text-ink' ?>">
               <?= $km ?> km
             </button>
           <?php endforeach ?>

--- a/app/Views/JourneyRequests/journeyRequestShowAll.php
+++ b/app/Views/JourneyRequests/journeyRequestShowAll.php
@@ -23,6 +23,20 @@
 
 <div class="max-w-4xl mx-auto py-10 px-4 space-y-6">
 
+    <?php if (session()->has('success')): ?>
+      <div class="bg-green-500/10 border border-green-500/30 rounded-xl p-4 flex gap-3 items-start">
+        <i class="fa-solid fa-circle-check text-green-500 text-base shrink-0 mt-0.5"></i>
+        <p class="text-ink text-sm"><?= esc(session('success')) ?></p>
+      </div>
+    <?php endif ?>
+
+    <?php if (session()->has('error')): ?>
+      <div class="bg-action/10 border border-action/30 rounded-xl p-4 flex gap-3 items-start">
+        <i class="fa-solid fa-triangle-exclamation text-action text-base shrink-0 mt-0.5"></i>
+        <p class="text-ink text-sm"><?= esc(session('error')) ?></p>
+      </div>
+    <?php endif ?>
+
     <div class="flex items-center justify-between">
         <h1 class="text-ink text-2xl font-bold font-display">Demander un trajet</h1>
         <div class="flex items-center gap-2">

--- a/app/Views/JourneyRequests/newJourneyRequest.php
+++ b/app/Views/JourneyRequests/newJourneyRequest.php
@@ -83,8 +83,8 @@
 
       <!-- Rayon -->
       <?php
-        $initRadius = (float) old('radius_km', 10);
-        $presets    = [5, 10];
+        $initRadius = (float) old('radius_km', 1);
+        $presets    = [1, 5, 10];
         $isCustom   = !in_array($initRadius, $presets);
       ?>
       <div class="mt-5 pt-5 border-t border-action/10">
@@ -92,7 +92,7 @@
         <div class="flex gap-2 flex-wrap items-center">
           <?php foreach ($presets as $km): ?>
             <button type="button" data-radius="<?= $km ?>"
-              class="radius-pill border rounded-lg px-4 py-2 text-sm font-medium transition-colors <?= !$isCustom && $initRadius === $km ? 'bg-action text-ink border-action' : 'border-action/20 text-ink/50 hover:border-action/50 hover:text-ink' ?>">
+              class="radius-pill border rounded-lg px-4 py-2 text-sm font-medium transition-colors <?= !$isCustom && $initRadius == $km ? 'bg-action text-ink border-action' : 'border-action/20 text-ink/50 hover:border-action/50 hover:text-ink' ?>">
               <?= $km ?> km
             </button>
           <?php endforeach ?>

--- a/app/Views/JourneyRequests/newJourneyRequest.php
+++ b/app/Views/JourneyRequests/newJourneyRequest.php
@@ -1,3 +1,6 @@
+<?php
+/** @var string $title */
+?>
 <?= view('partials/head', [
   'extraCss' => [
     'https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css',
@@ -77,6 +80,68 @@
         </div>
 
       </div>
+
+      <!-- Rayon -->
+      <?php
+        $initRadius = (float) old('radius_km', 10);
+        $presets    = [5, 10];
+        $isCustom   = !in_array($initRadius, $presets);
+      ?>
+      <div class="mt-5 pt-5 border-t border-action/10">
+        <label class="text-ink/50 text-xs font-medium mb-2 block">Rayon de recherche autour de mes adresses</label>
+        <div class="flex gap-2 flex-wrap items-center">
+          <?php foreach ($presets as $km): ?>
+            <button type="button" data-radius="<?= $km ?>"
+              class="radius-pill border rounded-lg px-4 py-2 text-sm font-medium transition-colors <?= !$isCustom && $initRadius === $km ? 'bg-action text-ink border-action' : 'border-action/20 text-ink/50 hover:border-action/50 hover:text-ink' ?>">
+              <?= $km ?> km
+            </button>
+          <?php endforeach ?>
+          <div class="radius-custom-pill flex items-center border rounded-lg px-3 py-2 gap-1 transition-colors <?= $isCustom ? 'bg-action border-action' : 'border-action/20 hover:border-action/50' ?>">
+            <input type="number" id="customRadiusInput" min="0.1" max="200" step="0.1" placeholder="—"
+              value="<?= $isCustom ? $initRadius : '' ?>"
+              class="w-10 bg-transparent text-sm font-medium outline-none placeholder:text-ink/30 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none <?= $isCustom ? 'text-ink' : 'text-ink/50' ?>">
+            <span class="text-sm font-medium transition-colors <?= $isCustom ? 'text-ink' : 'text-ink/50' ?>">km</span>
+          </div>
+          <input type="hidden" name="radius_km" id="radiusKmInput" value="<?= esc($initRadius) ?>">
+        </div>
+        <p class="mt-2 text-ink/30 text-xs">Astuce : 0.5 = 500 m, 0.1 = 100 m</p>
+      </div>
+      <script>
+      (function() {
+        const pills  = document.querySelectorAll('.radius-pill');
+        const cpill  = document.querySelector('.radius-custom-pill');
+        const cinput = document.getElementById('customRadiusInput');
+        const hidden = document.getElementById('radiusKmInput');
+        const on     = ['bg-action', 'text-ink', 'border-action'];
+        const off    = ['border-action/20', 'text-ink/50'];
+
+        function activatePreset(btn) {
+          pills.forEach(p => { p.classList.remove(...on); p.classList.add(...off); });
+          btn.classList.add(...on); btn.classList.remove(...off);
+          cpill.classList.remove(...on); cpill.classList.add('border-action/20');
+          cinput.classList.remove('text-ink'); cinput.classList.add('text-ink/50');
+          cinput.value = '';
+        }
+
+        function activateCustom() {
+          pills.forEach(p => { p.classList.remove(...on); p.classList.add(...off); });
+          cpill.classList.add(...on); cpill.classList.remove('border-action/20');
+          cinput.classList.add('text-ink'); cinput.classList.remove('text-ink/50');
+        }
+
+        pills.forEach(p => p.addEventListener('click', () => {
+          activatePreset(p);
+          hidden.value = p.dataset.radius;
+        }));
+
+        cinput.addEventListener('focus', activateCustom);
+        cinput.addEventListener('input', () => {
+          activateCustom();
+          if (cinput.value) hidden.value = cinput.value;
+        });
+      })();
+      </script>
+
     </div>
 
     <!-- Date & heure -->

--- a/app/Views/Profile/notifications.php
+++ b/app/Views/Profile/notifications.php
@@ -1,0 +1,75 @@
+<?php
+
+/** @var array $prefs        [slug => bool]  */
+/** @var array $prefLabels   [slug => label] */
+?>
+<?= view('partials/head') ?>
+<?= view('partials/header') ?>
+
+<div class="max-w-4xl mx-auto py-10 px-4 flex flex-col gap-6">
+
+  <div class="flex items-center justify-between">
+    <h1 class="text-ink text-2xl font-bold font-display">Préférences de notifications</h1>
+    <a href="<?= site_url('profile') ?>" class="text-ink/50 hover:text-action text-sm flex items-center gap-1.5 transition-colors">
+      <i class="fa-solid fa-arrow-left text-xs"></i>Retour
+    </a>
+  </div>
+
+  <?php if (session()->getFlashdata('success')): ?>
+    <div class="bg-success/10 border border-success/20 rounded-xl px-5 py-3 text-success text-sm flex items-center gap-2">
+      <i class="fa-solid fa-circle-check shrink-0"></i>
+      <?= esc(session()->getFlashdata('success')) ?>
+    </div>
+  <?php endif; ?>
+
+  <p class="text-ink/50 text-sm">
+    Choisissez les emails que vous souhaitez recevoir. Les emails de sécurité (mot de passe, connexion, compte) sont toujours envoyés.
+  </p>
+
+  <form action="<?= site_url('profile/notifications') ?>" method="post">
+    <?= csrf_field() ?>
+
+    <div class="bg-surface rounded-2xl border border-action/10 divide-y divide-action/10">
+
+      <?php foreach ($prefLabels as $slug => $label): ?>
+        <label class="flex items-start gap-4 p-5 cursor-pointer hover:bg-action/5 transition-colors">
+          <div class="pt-0.5 shrink-0">
+            <input
+              type="checkbox"
+              name="prefs[]"
+              value="<?= esc($slug) ?>"
+              <?= ($prefs[$slug] ?? true) ? 'checked' : '' ?>
+              class="w-4 h-4 rounded accent-action cursor-pointer"
+            >
+          </div>
+          <div class="flex-1 min-w-0">
+            <p class="text-ink text-sm font-medium leading-snug"><?= esc($label) ?></p>
+          </div>
+        </label>
+      <?php endforeach; ?>
+
+    </div>
+
+    <div class="flex justify-end gap-3 mt-4">
+      <button type="button" id="checkAll" class="text-sm text-ink/50 hover:text-action transition-colors">Tout activer</button>
+      <span class="text-ink/20">·</span>
+      <button type="button" id="uncheckAll" class="text-sm text-ink/50 hover:text-action transition-colors">Tout désactiver</button>
+      <button type="submit"
+        class="ml-4 bg-action hover:bg-action-dark text-ink font-semibold font-display rounded-lg px-5 py-2 text-sm transition-colors">
+        Enregistrer
+      </button>
+    </div>
+  </form>
+
+</div>
+
+<script>
+  document.getElementById('checkAll').addEventListener('click', () => {
+    document.querySelectorAll('input[name="prefs[]"]').forEach(cb => cb.checked = true);
+  });
+  document.getElementById('uncheckAll').addEventListener('click', () => {
+    document.querySelectorAll('input[name="prefs[]"]').forEach(cb => cb.checked = false);
+  });
+</script>
+
+<?= view('partials/footer') ?>

--- a/app/Views/Profile/show.php
+++ b/app/Views/Profile/show.php
@@ -77,6 +77,10 @@
             class="flex items-center gap-2 bg-action hover:bg-action-dark text-ink font-semibold font-display rounded-lg px-4 py-2 text-sm transition-colors">
             <i class="fa-solid fa-pen text-xs"></i>Modifier le profil
           </a>
+          <a href="<?= site_url('profile/notifications') ?>"
+            class="flex items-center gap-2 border border-action/30 hover:border-action/60 text-ink/70 hover:text-ink font-semibold font-display rounded-lg px-4 py-2 text-sm transition-colors">
+            <i class="fa-solid fa-bell text-xs"></i>Notifications
+          </a>
         </div>
       <?php endif; ?>
     </div>

--- a/app/Views/unsubscribe.php
+++ b/app/Views/unsubscribe.php
@@ -1,0 +1,66 @@
+<?php
+/** @var bool   $success */
+/** @var string $label */
+?>
+<?= view('partials/head') ?>
+<?= view('partials/header') ?>
+
+<div class="min-h-[70vh] flex items-center justify-center px-4 py-16">
+  <div class="bg-surface rounded-2xl border border-action/10 w-full max-w-sm p-8 flex flex-col items-center text-center gap-6">
+
+    <?php if ($success): ?>
+
+      <div class="w-16 h-16 rounded-2xl bg-success/10 border border-success/20 flex items-center justify-center">
+        <i class="fa-solid fa-bell-slash text-success text-2xl"></i>
+      </div>
+
+      <div class="flex flex-col gap-2">
+        <h1 class="text-ink text-xl font-bold font-display">Désabonnement effectué</h1>
+        <p class="text-ink/50 text-sm leading-relaxed">
+          Vous ne recevrez plus les emails<br>
+          <span class="text-ink/80 font-medium">« <?= esc($label) ?> »</span>
+        </p>
+      </div>
+
+      <div class="w-full border-t border-action/10 pt-5 flex flex-col gap-3">
+        <a href="<?= site_url('profile/notifications') ?>"
+           class="w-full bg-action hover:bg-action-dark text-ink font-semibold font-display rounded-lg px-5 py-2.5 text-sm transition-colors text-center">
+          Gérer toutes mes préférences
+        </a>
+        <a href="<?= site_url('/') ?>"
+           class="text-ink/40 hover:text-ink/70 text-xs transition-colors">
+          Retour à l'accueil
+        </a>
+      </div>
+
+    <?php else: ?>
+
+      <div class="w-16 h-16 rounded-2xl bg-action/10 border border-action/20 flex items-center justify-center">
+        <i class="fa-solid fa-link-slash text-action text-2xl"></i>
+      </div>
+
+      <div class="flex flex-col gap-2">
+        <h1 class="text-ink text-xl font-bold font-display">Lien invalide</h1>
+        <p class="text-ink/50 text-sm leading-relaxed">
+          Ce lien de désabonnement est invalide ou a expiré.<br>
+          Connectez-vous pour gérer vos préférences manuellement.
+        </p>
+      </div>
+
+      <div class="w-full border-t border-action/10 pt-5 flex flex-col gap-3">
+        <a href="<?= site_url('profile/notifications') ?>"
+           class="w-full bg-action hover:bg-action-dark text-ink font-semibold font-display rounded-lg px-5 py-2.5 text-sm transition-colors text-center">
+          Gérer mes préférences
+        </a>
+        <a href="<?= site_url('/') ?>"
+           class="text-ink/40 hover:text-ink/70 text-xs transition-colors">
+          Retour à l'accueil
+        </a>
+      </div>
+
+    <?php endif; ?>
+
+  </div>
+</div>
+
+<?= view('partials/footer') ?>

--- a/public/js/journeySelection.js
+++ b/public/js/journeySelection.js
@@ -23,6 +23,13 @@
         cancelSelectedBtn.disabled = checked.length === 0;
         cancelSelectedBtn.classList.toggle('opacity-40', checked.length === 0);
         cancelSelectedBtn.classList.toggle('cursor-not-allowed', checked.length === 0);
+        journeyList.querySelectorAll('.journey-card').forEach((card) => {
+            const cb = card.querySelector('input[type="checkbox"]');
+            if (cb) {
+                card.classList.toggle('ring-2', cb.checked);
+                card.classList.toggle('ring-action/40', cb.checked);
+            }
+        });
     }
 
     function enterSelectionMode() {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,8 @@ module.exports = {
   ],
   safelist: [
     'animate-bounce',
+    'ring-2',
+    'ring-action/40',
   ],
   theme: {
     extend: {


### PR DESCRIPTION
- Vérification d'email à l'inscription — un email avec lien de confirmation (valable 24h) est envoyé avant toute validation admin. Le compte reste en statut unverified jusqu'au clic, puis passe en pending.
- Préférences de notifications — nouvelle table user_notification_pref et page /profile/notifications permettant de choisir email par email quels types de notifications recevoir (8 types granulaires). Les préférences admin_* sont réservées aux admins. Modèle opt-out : l'absence de ligne = activé par défaut.
- Désabonnement one-click — chaque email transactionnel contient un footer avec un lien de désabonnement signé (HMAC-SHA256, sans stockage en base) et un lien vers les préférences.
- Page /unsubscribe — page dédiée avec retour visuel succès/erreur, aux couleurs du site.
- Outils de test emails (dev uniquement) — /dev/email/{template} pour prévisualiser dans le navigateur, /dev/email/{template}/send?to= pour envoyer via Brevo.


1. NotificationPrefModel — nouveau modèle avec wantsNotif(), getAllForUser(), saveForUser()
2. AuthController::verifyEmail() — vérifie le token, notifie les admins éligibles
3. UserModel::unsubscribeToken() (statique) — génère le token HMAC utilisable depuis n'importe quel service
4. Emails/_notifFooter.php — partial injecté dans les 8 templates d'emails

Il faudra faire un php spark migrate